### PR TITLE
feat: add global-css-to-css-module codemod POC

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,20 @@
-function main(): void {
-    console.log('Hello world!')
+import path from 'path'
+
+import { Project } from 'ts-morph'
+
+import { globalCssToCssModule } from './transforms/globalCssToCssModule/globalCssToCssModule'
+
+// TODO: add interactive CLI support
+const TARGET_FILE = path.resolve(__dirname, './transforms/globalCssToCssModule/__tests__/fixtures/Kek.tsx')
+
+async function main(): Promise<void> {
+    const project = new Project()
+    project.addSourceFilesAtPaths(TARGET_FILE)
+
+    const result = await globalCssToCssModule(project)
+    console.log(result)
 }
 
-main()
+main().catch(error => {
+    throw error
+})

--- a/src/transforms/globalCssToCssModule/__tests__/__snapshots__/globalCssToCssModule.test.ts.snap
+++ b/src/transforms/globalCssToCssModule/__tests__/__snapshots__/globalCssToCssModule.test.ts.snap
@@ -1,0 +1,145 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`globalCssToCssModule transforms correctly 1`] = `
+"@import './RepositoriesPopover';
+
+/* Woah!*/
+.kek {
+    color: red;
+
+    /* nah*/
+    &--wow {
+        color: blue;
+    }
+}
+
+/* Let's see how you handle global top-level classes!*/
+:global(.theme-redesign) .kek {
+    color: red;
+}
+
+/* .repo-header {*/
+.repo-header {
+    flex: none;
+    padding: 0;
+    align-items: stretch;
+    border-color: var(--border-color);
+    border-style: solid;
+
+    /* &--alert {*/
+    &--alert {
+        border-width: 1px 0;
+    }
+
+    /* .navbar-nav {*/
+    :global(.navbar-nav) {
+        white-space: nowrap;
+
+        :global(.nav-item) {
+            display: flex;
+            align-items: stretch;
+
+            /* .nav-link {*/
+            :global(.nav-link) {
+                user-select: none;
+            }
+        }
+    }
+
+    :global(.copy-link-action) {
+        opacity: 0;
+    }
+    &:hover,
+    &:focus-within {
+        :global(.copy-link-action) {
+            opacity: 1;
+        }
+    }
+}
+.spacer {
+        flex: 1 1 0;
+    }
+
+/* &__icon-chevron {*/
+.icon-chevron {
+        opacity: 0.6;
+        margin: auto;
+    }
+.alert {
+        margin: 0 0.25rem;
+        padding: 0.125rem 0.25rem;
+        cursor: default;
+        user-select: none;
+    }
+
+/* &__action {*/
+.action {
+        margin: 0.5rem 0.625rem 0.5rem 0;
+        padding: 0.25rem;
+
+        :global(.theme-redesign) & {
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+    }
+
+/* &__file-action {*/
+.file-action {
+        display: block;
+        text-align: left;
+
+        /* span {*/
+        span {
+            color: var(--body-color);
+            margin-left: 0.5rem;
+        }
+    }
+
+/* &__action-list-item {*/
+.action-list-item {
+        /* Have a small gap between buttons so they are visually distinct when pressed*/
+        /* stylelint-disable-next-line declaration-property-unit-whitelist*/
+        margin-left: 1px;
+
+        /* &:hover {*/
+        &:hover {
+            /* background: var(--color-bg-1);*/
+            background: var(--color-bg-1);
+
+            /* .theme-redesign & {*/
+            :global(.theme-redesign) & {
+                background: inherit;
+            }
+        }
+    }
+
+/* &__kek-pek {*/
+.kek-pek {
+            color: red;
+        }
+"
+`;
+
+exports[`globalCssToCssModule transforms correctly 2`] = `
+"import React from 'react'
+import classNames from \\"classnames\\";
+import styles from \\"./Kek.module.scss\\";
+
+export const Kek = () => {
+    const isActive = true
+
+    return (
+        <div className={classNames(\\"d-flex m-1\\", styles.kek, styles.kekWow)}>
+            <div
+                className={classNames('m-1', true ? styles.kek : false, 'd-flex', {
+                    [styles.kek]: false,
+                    [classNames(\\"d-flex mr-1\\", styles.kek)]: isActive,
+                })}
+            ></div>
+            It's a component<p className={styles.kekWow}>wow</p>
+            <div className={classNames(\\"m-2 d-flex m-1\\", styles.repoHeader)}>Another one!</div>
+        </div>
+    )
+}
+"
+`;

--- a/src/transforms/globalCssToCssModule/__tests__/fixtures/Kek.scss
+++ b/src/transforms/globalCssToCssModule/__tests__/fixtures/Kek.scss
@@ -1,0 +1,118 @@
+@import './RepositoriesPopover';
+
+// Woah!
+.kek {
+    color: red;
+
+    // nah
+    &--wow {
+        color: blue;
+    }
+}
+
+// Let's see how you handle global top-level classes!
+.theme-redesign .kek {
+    color: red;
+}
+
+// .repo-header {
+.repo-header {
+    flex: none;
+    padding: 0;
+    align-items: stretch;
+    border-color: var(--border-color);
+    border-style: solid;
+
+    // &--alert {
+    &--alert {
+        border-width: 1px 0;
+    }
+
+    // &__action-list-item {
+    &__action-list-item {
+        // Have a small gap between buttons so they are visually distinct when pressed
+        // stylelint-disable-next-line declaration-property-unit-whitelist
+        margin-left: 1px;
+
+        // &__kek-pek {
+        &__kek-pek {
+            color: red;
+        }
+
+        // &:hover {
+        &:hover {
+            // background: var(--color-bg-1);
+            background: var(--color-bg-1);
+
+            // .theme-redesign & {
+            .theme-redesign & {
+                background: inherit;
+            }
+        }
+    }
+
+    // &__file-action {
+    &__file-action {
+        display: block;
+        text-align: left;
+
+        // span {
+        span {
+            color: var(--body-color);
+            margin-left: 0.5rem;
+        }
+    }
+
+    // &__action {
+    &__action {
+        margin: 0.5rem 0.625rem 0.5rem 0;
+        padding: 0.25rem;
+
+        .theme-redesign & {
+            margin-top: 0;
+            margin-bottom: 0;
+        }
+    }
+
+    // .navbar-nav {
+    .navbar-nav {
+        white-space: nowrap;
+
+        .nav-item {
+            display: flex;
+            align-items: stretch;
+
+            // .nav-link {
+            .nav-link {
+                user-select: none;
+            }
+        }
+    }
+
+    &__alert {
+        margin: 0 0.25rem;
+        padding: 0.125rem 0.25rem;
+        cursor: default;
+        user-select: none;
+    }
+
+    // &__icon-chevron {
+    &__icon-chevron {
+        opacity: 0.6;
+        margin: auto;
+    }
+
+    .copy-link-action {
+        opacity: 0;
+    }
+    &:hover,
+    &:focus-within {
+        .copy-link-action {
+            opacity: 1;
+        }
+    }
+
+    &__spacer {
+        flex: 1 1 0;
+    }
+}

--- a/src/transforms/globalCssToCssModule/__tests__/fixtures/Kek.tsx
+++ b/src/transforms/globalCssToCssModule/__tests__/fixtures/Kek.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export const Kek = () => {
+    const isActive = true
+
+    return (
+        <div className="kek kek--wow d-flex m-1">
+            <div
+                className={classNames('m-1', true ? 'kek' : false, 'd-flex', {
+                    kek: false,
+                    'd-flex mr-1 kek': isActive,
+                })}
+            ></div>
+            It's a component<p className="kek--wow">wow</p>
+            <div className="m-2 repo-header d-flex m-1">Another one!</div>
+        </div>
+    )
+}

--- a/src/transforms/globalCssToCssModule/__tests__/globalCssToCssModule.test.ts
+++ b/src/transforms/globalCssToCssModule/__tests__/globalCssToCssModule.test.ts
@@ -1,0 +1,19 @@
+import path from 'path'
+
+import { Project } from 'ts-morph'
+
+import { globalCssToCssModule } from '../globalCssToCssModule'
+
+const TARGET_FILE = path.resolve(__dirname, './fixtures/Kek.tsx')
+
+// TODO: split into granular atomic tests.
+describe('globalCssToCssModule', () => {
+    it('transforms correctly', async () => {
+        const project = new Project()
+        project.addSourceFilesAtPaths(TARGET_FILE)
+        const [transformResult] = await globalCssToCssModule(project)
+
+        expect(transformResult.css.source).toMatchSnapshot()
+        expect(transformResult.ts.source).toMatchSnapshot()
+    })
+})

--- a/src/transforms/globalCssToCssModule/globalCssToCssModule.ts
+++ b/src/transforms/globalCssToCssModule/globalCssToCssModule.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+
+import { Project } from 'ts-morph'
+
+import { getCssModuleExportNameMap } from './postcss/getCssModuleExportNameMap'
+import { transformFileToCssModule } from './postcss/transformFileToCssModule'
+import { addClassNamesUtilImportIfNeeded } from './ts/classNamesUtility'
+import { getNodesWithClassName } from './ts/getNodesWithClassName'
+import { STYLES_IDENTIFIER, processNodesWithClassName } from './ts/processNodesWithClassName'
+
+interface CodemodResult {
+    css: {
+        source: string
+        path: string
+    }
+    ts: {
+        source: string
+        path: string
+    }
+}
+
+/**
+ * Convert globally scoped stylesheet tied to the React component into a CSS Module.
+ *
+ * 1) Find `.tsx` file.
+ * 2) Check if corresponding `.scss` file exists in the same folder.
+ * 3) Convert this `.scss` file into `.module.scss`.
+ * 4) Get info about CSS class names and matching export tokens.
+ * 5) Replace all matching class names with export tokens.
+ * 6) Add `classNames` import to the `.tsx` file if needed.
+ * 7) Add `.module.scss` import to the `.tsx` file.
+ *
+ */
+export function globalCssToCssModule(project: Project): Promise<CodemodResult[]> {
+    const codemodResults = project.getSourceFiles().map(async sourceFile => {
+        const filePath = sourceFile.getFilePath()
+
+        const parsedTsFilePath = path.parse(filePath)
+        const cssFilePath = path.resolve(parsedTsFilePath.dir, `${parsedTsFilePath.name}.scss`)
+
+        // TODO: add check if SCSS file doesn't exist and exit if it's not found.
+        const sourceCss = readFileSync(cssFilePath, 'utf8')
+        const exportNameMap = await getCssModuleExportNameMap(sourceCss)
+        const { css: cssModuleSource, filePath: cssModuleFileName } = await transformFileToCssModule(
+            sourceCss,
+            cssFilePath
+        )
+
+        processNodesWithClassName({
+            exportNameMap,
+            nodesWithClassName: getNodesWithClassName(sourceFile),
+        })
+
+        addClassNamesUtilImportIfNeeded(sourceFile)
+        sourceFile.addImportDeclaration({
+            defaultImport: STYLES_IDENTIFIER,
+            moduleSpecifier: `./${path.parse(cssModuleFileName).base}`,
+        })
+
+        // TODO: run prettier and eslint --fix over updated files.
+        return {
+            css: {
+                source: cssModuleSource,
+                path: path.resolve(parsedTsFilePath.dir, cssModuleFileName),
+            },
+            ts: {
+                source: sourceFile.getFullText(),
+                path: sourceFile.getFilePath(),
+            },
+        }
+    })
+
+    return Promise.all(codemodResults)
+}

--- a/src/transforms/globalCssToCssModule/postcss/createCssProcessor.ts
+++ b/src/transforms/globalCssToCssModule/postcss/createCssProcessor.ts
@@ -1,0 +1,12 @@
+import postcss, { AcceptedPlugin, LazyResult } from 'postcss'
+import postcssScss from 'postcss-scss'
+
+export const createCssProcessor = (...plugins: AcceptedPlugin[]): ((css: string) => LazyResult) => {
+    const configuredProcessor = postcss(plugins)
+
+    return (css: string) =>
+        configuredProcessor.process(css, {
+            parser: postcssScss,
+            from: 'CSS',
+        })
+}

--- a/src/transforms/globalCssToCssModule/postcss/getCssModuleExportNameMap.ts
+++ b/src/transforms/globalCssToCssModule/postcss/getCssModuleExportNameMap.ts
@@ -1,0 +1,27 @@
+import camelcase from 'camelcase'
+import CssModuleLoaderCore, { Source } from 'css-modules-loader-core'
+import postcssNested from 'postcss-nested'
+
+import { createCssProcessor } from './createCssProcessor'
+
+const EXPORT_NAME_PREFIX = 'prefix'
+
+// The simplest subset of logic used by css-modules loaders and processors.
+const cssModulesLoaderCore = new CssModuleLoaderCore()
+const noOpPathFetcher = (): void => {}
+const sourceCssToClassNames = (source: Source): Promise<Core.Result> =>
+    cssModulesLoaderCore.load(source, EXPORT_NAME_PREFIX, undefined, noOpPathFetcher)
+
+const removeCssNestingProcessor = createCssProcessor(postcssNested)
+
+// Get a mapping between export names that will be used in the TS file and CSS classes.
+export async function getCssModuleExportNameMap(sourceCss: string): Promise<Record<string, string>> {
+    const flattenedResult = await removeCssNestingProcessor(sourceCss)
+    const classNames = await sourceCssToClassNames(flattenedResult.css)
+
+    const exportNameClassNamePairs: [string, string][] = Object.entries(classNames.exportTokens).map(
+        ([property, className]) => [className.replace(`_${EXPORT_NAME_PREFIX}__`, ''), camelcase(property)]
+    )
+
+    return Object.fromEntries<string>(exportNameClassNamePairs)
+}

--- a/src/transforms/globalCssToCssModule/postcss/postcssToCssModulePlugin.ts
+++ b/src/transforms/globalCssToCssModule/postcss/postcssToCssModulePlugin.ts
@@ -1,0 +1,135 @@
+import { AcceptedPlugin, Rule, ChildNode } from 'postcss'
+import parser, { isRoot, Selector } from 'postcss-selector-parser'
+
+const GLOBAL_TOP_LEVEL_CLASSES = ['.theme-redesign', '.theme-light', '.theme-dark']
+
+// Based on the implementation of the `postcss-nested` plugin:
+// https://github.com/postcss/postcss-nested/blob/main/index.js
+export function postcssToCssModulePlugin(): AcceptedPlugin {
+    return {
+        postcssPlugin: 'postcss-to-css-module',
+        Root(root) {
+            if (root.last) {
+                // Remove default spacing applied by postcss.
+                root.last.raws.before = undefined
+            }
+        },
+        Rule(parentRule) {
+            const isRootRule = isRoot(parentRule.parent)
+
+            // Check if root level selectors include well-known global classes and wrap them
+            // into a `:global()` keyword in case of a match.
+            if (isRootRule && GLOBAL_TOP_LEVEL_CLASSES.some(globalClass => parentRule.selector.includes(globalClass))) {
+                for (const globalClass of GLOBAL_TOP_LEVEL_CLASSES) {
+                    parentRule.selector = parentRule.selector.replace(
+                        globalClass,
+                        wrapSelectorInGlobalKeyword(globalClass)
+                    )
+                }
+            }
+
+            // Go through all child selectors and remove redundant nesting according to our guidelines:
+            // https://docs.sourcegraph.com/dev/background-information/web/styling#css-modules
+            parentRule.each(child => {
+                if (child.type === 'rule') {
+                    child.selectors = updateChildSelectors(parentRule, child)
+                }
+            })
+        },
+    }
+}
+
+function updateChildSelectors(parent: Rule, child: Rule): string[] {
+    let shouldRemoveNesting = false
+
+    const updatedChildSelectors = child.selectors.reduce<string[]>((result, selectorString) => {
+        if (selectorString.length !== 0) {
+            const selectorNode = parse(selectorString, child)
+            shouldRemoveNesting = replaceSelectorNodesIfNeeded(selectorNode)
+
+            result.push(selectorNode.toString())
+        }
+
+        return result
+    }, [])
+
+    // If nesting was removed, uplift nested selector to the direct child level.
+    if (shouldRemoveNesting) {
+        // Preserve comment above the selector on nesting removal.
+        const parentOrComment = pickComment(child.prev(), parent)
+        parentOrComment.after(child)
+    }
+
+    return updatedChildSelectors
+}
+
+function replaceSelectorNodesIfNeeded(nodes: Selector): boolean {
+    return nodes.reduce<boolean>((shouldRemoveNesting, node) => {
+        // Assume that all nested classes not starting with `&` are global classes:
+        // .menu {
+        //   .nav-bar -> :global(.nav-bar)
+        // }
+        if (node.type === 'class') {
+            const globalClass = wrapSelectorInGlobalKeyword(node.toString())
+            node.replaceWith(parse(globalClass))
+        }
+
+        if (node.type === 'nesting') {
+            if (node.value !== '&') {
+                throw new Error(`Found unhandled nesting! ${node.value}`)
+            } else {
+                const nextNode = node.next()
+
+                if (nextNode) {
+                    if (nextNode.value?.startsWith('--')) {
+                        // Preserve nesting for modifier classes, e.g., `&--disabled`
+                    } else if (nextNode.value?.startsWith('__')) {
+                        // Remove nesting for selectors starting from `__`
+                        // &__button -> .button
+                        node.replaceWith(parse(''))
+                        nextNode.replaceWith(parse(nextNode.value?.replace('__', '.')))
+                        return true
+                    }
+                }
+            }
+        }
+
+        return shouldRemoveNesting
+    }, false)
+}
+
+function wrapSelectorInGlobalKeyword(selector: string): string {
+    return `:global(${selector})`
+}
+
+// If passed node is a comment -> attach it to the end of the file and return it, otherwise return the passed node.
+function pickComment(maybeCommentNode: ChildNode | undefined, parent: Rule): Rule {
+    if (maybeCommentNode && maybeCommentNode.type === 'comment') {
+        parent.after(maybeCommentNode)
+        return maybeCommentNode as unknown as Rule
+    }
+
+    return parent
+}
+
+// Logic without changes from the `postcss-nested`:
+// https://github.com/postcss/postcss-nested/blob/main/index.js#L3
+function parse(source: string, rule?: Rule): Selector {
+    let nodes: parser.Root | undefined
+
+    const saver = parser(parsed => {
+        nodes = parsed
+    })
+
+    try {
+        saver.processSync(source)
+    } catch (error) {
+        if (source.includes(':')) {
+            throw rule ? rule.error('Missed semicolon') : error
+        } else {
+            throw rule ? rule.error(error.message) : error
+        }
+    }
+
+    return nodes!.at(0)
+}

--- a/src/transforms/globalCssToCssModule/postcss/transformFileToCssModule.ts
+++ b/src/transforms/globalCssToCssModule/postcss/transformFileToCssModule.ts
@@ -1,0 +1,34 @@
+import { writeFileSync, rmSync } from 'fs'
+import path from 'path'
+
+import { createCssProcessor } from './createCssProcessor'
+import { postcssToCssModulePlugin } from './postcssToCssModulePlugin'
+
+const transformFileToCssModuleProcessor = createCssProcessor(postcssToCssModulePlugin())
+
+interface TransformFileToCssModuleResult {
+    css: string
+    filePath: string
+}
+
+export async function transformFileToCssModule(
+    sourceCss: string,
+    sourceFilePath: string
+): Promise<TransformFileToCssModuleResult> {
+    const transformedResult = await transformFileToCssModuleProcessor(sourceCss)
+
+    const { dir, name } = path.parse(sourceFilePath)
+    const newFilePath = path.join(dir, `${name}.module.scss`)
+
+    // TODO: add option to write files.
+    // eslint-disable-next-line no-constant-condition
+    if (false) {
+        writeFileSync(newFilePath, transformedResult.css)
+        rmSync(sourceFilePath)
+    }
+
+    return {
+        css: transformedResult.css,
+        filePath: newFilePath,
+    }
+}

--- a/src/transforms/globalCssToCssModule/ts/classNamesUtility.ts
+++ b/src/transforms/globalCssToCssModule/ts/classNamesUtility.ts
@@ -1,0 +1,28 @@
+import { ts, SourceFile, SyntaxKind } from 'ts-morph'
+import { Expression } from 'typescript'
+
+const CLASSNAMES_IDENTIFIER = 'classNames'
+const CLASSNAMES_MODULE_SPECIFIER = CLASSNAMES_IDENTIFIER.toLowerCase()
+
+// Wraps array of arguments into a `classNames` function call.
+export function wrapIntoClassNamesUtility(classNames: Expression[]): ts.CallExpression {
+    return ts.factory.createCallExpression(ts.factory.createIdentifier(CLASSNAMES_IDENTIFIER), undefined, classNames)
+}
+
+// Adds `classnames` import to the `sourceFile` if `classNames` util is used and import doesn't exist.
+export function addClassNamesUtilImportIfNeeded(sourceFile: SourceFile): void {
+    const isClassNamesUsed = sourceFile
+        .getDescendantsOfKind(SyntaxKind.Identifier)
+        .some(identifier => identifier.getText() === CLASSNAMES_IDENTIFIER)
+
+    const hasClassNamesImport = sourceFile
+        .getImportDeclarations()
+        .some(declaration => declaration.getModuleSpecifier().getLiteralText() === CLASSNAMES_MODULE_SPECIFIER)
+
+    if (isClassNamesUsed && !hasClassNamesImport) {
+        sourceFile.addImportDeclaration({
+            defaultImport: CLASSNAMES_IDENTIFIER,
+            moduleSpecifier: CLASSNAMES_MODULE_SPECIFIER,
+        })
+    }
+}

--- a/src/transforms/globalCssToCssModule/ts/getClassNameNodeReplacement.ts
+++ b/src/transforms/globalCssToCssModule/ts/getClassNameNodeReplacement.ts
@@ -1,0 +1,47 @@
+import { ts, JsxAttribute, PropertyAssignment, NodeParentType, ConditionalExpression } from 'ts-morph'
+import { Expression, StringLiteral, JsxExpression, ComputedPropertyName, PropertyAccessExpression } from 'typescript'
+
+import { wrapIntoClassNamesUtility } from './classNamesUtility'
+
+interface GetClassNameNodeReplacementResult {
+    parentNode: NodeParentType<StringLiteral>
+    leftOverClassName: string
+    exportNameReferences: PropertyAccessExpression[]
+}
+
+export function getClassNameNodeReplacement(
+    options: GetClassNameNodeReplacementResult
+): PropertyAccessExpression | JsxExpression | ComputedPropertyName {
+    const { parentNode, leftOverClassName, exportNameReferences } = options
+
+    if (parentNode instanceof JsxAttribute || parentNode instanceof PropertyAssignment) {
+        const wrapIntoCorrectBraces =
+            parentNode instanceof JsxAttribute
+                ? (expression: Expression) => ts.factory.createJsxExpression(undefined, expression)
+                : (expression: Expression) => ts.factory.createComputedPropertyName(expression)
+
+        // We need to use `classNames` utility for multiple `exportNames` or for a combination of the `exportName` and `StringLiteral`.
+        // className={classNames('d-flex mr-1 kek kek--primary')} -> className={classNames('d-flex mr-1', styles.kek, styles.kekPrimary)}
+        if (leftOverClassName || exportNameReferences.length > 1) {
+            const classNamesCallArguments: Expression[] = [...exportNameReferences]
+
+            if (leftOverClassName) {
+                classNamesCallArguments.unshift(ts.factory.createStringLiteral(leftOverClassName))
+            }
+
+            return wrapIntoCorrectBraces(wrapIntoClassNamesUtility(classNamesCallArguments))
+        }
+
+        // Replace one class with the `exportName`.
+        // className='kek' -> className={styles.Kek}
+        return wrapIntoCorrectBraces(exportNameReferences[0])
+    }
+
+    if (parentNode instanceof ConditionalExpression) {
+        // Replace one class string inside of `ConditionalExpression` with the `exportName`.
+        // className={classNames('d-flex', isActive ? 'kek' : 'pek')} -> className={classNames('d-flex', isActive ? styles.kek : 'pek')}
+        return exportNameReferences[0]
+    }
+
+    throw new Error(`Unsupported 'parentNode' type: ${parentNode.compilerNode.kind}`)
+}

--- a/src/transforms/globalCssToCssModule/ts/getNodesWithClassName.ts
+++ b/src/transforms/globalCssToCssModule/ts/getNodesWithClassName.ts
@@ -1,0 +1,18 @@
+import { StringLiteral, Identifier, SyntaxKind, SourceFile } from 'ts-morph'
+
+export function getNodesWithClassName(sourceFile: SourceFile): (Identifier | StringLiteral)[] {
+    const jsxAttributes = sourceFile.getDescendantsOfKind(SyntaxKind.JsxAttribute)
+    const classNameJsxAttributes = jsxAttributes.filter(identifier => identifier.getName() === 'className')
+
+    // <div className={classNames({ kek: isActive })} /> — 'kek' is an `Identifier` inside of the `PropertyAssignment`.
+    const classNameIdentifiers = classNameJsxAttributes
+        .flatMap(classNameJsxAttribute => classNameJsxAttribute.getDescendantsOfKind(SyntaxKind.Identifier))
+        .filter(identifier => identifier.getParent().compilerNode.kind === SyntaxKind.PropertyAssignment)
+
+    // <div className='kek' /> — 'kek' is a `StringLiteral` inside  of the `JsxAttribute`.
+    const classNameStringLiterals = classNameJsxAttributes.flatMap(classNameJsxAttribute =>
+        classNameJsxAttribute.getDescendantsOfKind(SyntaxKind.StringLiteral)
+    )
+
+    return [...classNameIdentifiers, ...classNameStringLiterals]
+}

--- a/src/transforms/globalCssToCssModule/ts/processNodesWithClassName.ts
+++ b/src/transforms/globalCssToCssModule/ts/processNodesWithClassName.ts
@@ -1,0 +1,42 @@
+import { ts, Identifier, StringLiteral } from 'ts-morph'
+
+import { getClassNameNodeReplacement } from './getClassNameNodeReplacement'
+import { splitClassName } from './splitClassName'
+
+export const STYLES_IDENTIFIER = 'styles'
+
+interface ProcessStringLiteralsOptions {
+    nodesWithClassName: (Identifier | StringLiteral)[]
+    exportNameMap: Record<string, string>
+}
+
+// Walk through all the `className` nodes and replace relevant classes with matching CSS module export names.
+export function processNodesWithClassName(options: ProcessStringLiteralsOptions): void {
+    const { nodesWithClassName, exportNameMap } = options
+
+    for (const nodeWithClassName of nodesWithClassName) {
+        const classNameStringValue =
+            nodeWithClassName instanceof StringLiteral
+                ? nodeWithClassName.getLiteralText()
+                : nodeWithClassName.getText()
+
+        const { exportNames, leftOverClassnames } = splitClassName(classNameStringValue, exportNameMap)
+
+        // There's nothing to update in this `className` node.
+        if (exportNames.length === 0) {
+            continue
+        }
+
+        const exportNameReferences = exportNames.map(exportName =>
+            ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier(STYLES_IDENTIFIER), exportName)
+        )
+
+        nodeWithClassName.transform(() =>
+            getClassNameNodeReplacement({
+                parentNode: nodeWithClassName.getParent(),
+                leftOverClassName: leftOverClassnames.join(' '),
+                exportNameReferences,
+            })
+        )
+    }
+}

--- a/src/transforms/globalCssToCssModule/ts/splitClassName.ts
+++ b/src/transforms/globalCssToCssModule/ts/splitClassName.ts
@@ -1,0 +1,32 @@
+interface SplitClassNameResult {
+    exportNames: string[]
+    leftOverClassnames: string[]
+}
+
+/**
+ * Example: splitClassName('kek--wow d-flex mr-1', { 'kek--wow': 'kekWow' })
+ * returns: { exportNames: ['kekWow'], leftOverClassnames: ['d-flex', 'mr-1'] }
+ *
+ * @param className ClassName value string which might contain replaceable parts.
+ * @param exportNameMap Mapping between classes and exportNames.
+ * @returns Object that contains array of exportNames found in the className and the left over value.
+ */
+export function splitClassName(className: string, exportNameMap: Record<string, string>): SplitClassNameResult {
+    const classNamesToReplace = Object.keys(exportNameMap)
+
+    return className.split(' ').reduce<SplitClassNameResult>(
+        (accumulator, className) => {
+            if (classNamesToReplace.includes(className)) {
+                accumulator.exportNames.push(exportNameMap[className])
+            } else {
+                accumulator.leftOverClassnames.push(className)
+            }
+
+            return accumulator
+        },
+        {
+            exportNames: [],
+            leftOverClassnames: [],
+        }
+    )
+}


### PR DESCRIPTION
## Context

This PR adds a proof of concept codemod that can automatically convert React component's stylesheet from global scope to CSS module. Detailed documentation, more granular tests and interactive CLI will be added in subsequent PRs. This PR adds the core logic on which it will be possible to iterate with smaller PRs.

## How it works

1) Find `.tsx` file. (At the moment, the file path is hardcoded for test purposes.)
2) Check if the corresponding `.scss` file exists in the same folder according to our naming convention.
3) Convert this `.scss` file into `.module.scss`.
4) Get info about CSS class names and matching export tokens that will be used in the React component markup.
5) Replace all matching class names with export tokens in the `.tsx` file. 
6) Add `classNames` import to the `.tsx` file if needed.
7) Add `.module.scss` import to the `.tsx` file.

Closes https://github.com/sourcegraph/sourcegraph/issues/23011.