### PR TITLE
fix: remove redundant prefixes for uplifted selectors

### DIFF
--- a/src/transforms/globalCssToCssModule/__tests__/__snapshots__/globalCssToCssModule.test.ts.snap
+++ b/src/transforms/globalCssToCssModule/__tests__/__snapshots__/globalCssToCssModule.test.ts.snap
@@ -116,6 +116,9 @@ exports[`globalCssToCssModule transforms correctly 1`] = `
 .kek-pek {
     color: red;
 }
+.logo {
+    display: flex;
+}
 "
 `;
 
@@ -136,7 +139,7 @@ export const Kek = () => {
                     [classNames('d-flex mr-1', styles.kek)]: isActive,
                 })}
              />
-            It's a component<p className={styles.kekWow}>wow</p>
+            It's a component<p className={styles.logo}>wow</p>
             <div className={classNames('m-2 d-flex m-1', styles.repoHeader)}>Another one!</div>
         </div>
     )

--- a/src/transforms/globalCssToCssModule/__tests__/fixtures/Kek.scss
+++ b/src/transforms/globalCssToCssModule/__tests__/fixtures/Kek.scss
@@ -28,6 +28,10 @@
         border-width: 1px 0;
     }
 
+    &__logo {
+        display: flex;
+    }
+
     // &__action-list-item {
     &__action-list-item {
         // Have a small gap between buttons so they are visually distinct when pressed

--- a/src/transforms/globalCssToCssModule/__tests__/fixtures/Kek.tsx
+++ b/src/transforms/globalCssToCssModule/__tests__/fixtures/Kek.tsx
@@ -11,7 +11,7 @@ export const Kek = () => {
                     'd-flex mr-1 kek': isActive,
                 })}
             ></div>
-            It's a component<p className="kek--wow">wow</p>
+            It's a component<p className="repo-header__logo">wow</p>
             <div className="m-2 repo-header d-flex m-1">Another one!</div>
         </div>
     )

--- a/src/transforms/globalCssToCssModule/postcss/__tests__/exportNameMapPrefixes.test.ts
+++ b/src/transforms/globalCssToCssModule/postcss/__tests__/exportNameMapPrefixes.test.ts
@@ -1,0 +1,45 @@
+import { removePrefixFromExportNameIfNeeded, getPrefixesToRemove } from '../exportNameMapPrefixes'
+
+describe('removePrefixFromExportNameIfNeeded', () => {
+    it('removes matching prefix', () => {
+        const exportName = removePrefixFromExportNameIfNeeded({
+            className: 'menu__button',
+            exportName: 'menuButton',
+            prefixesToRemove: [{ prefix: 'menu__', exportName: 'menu' }],
+        })
+
+        expect(exportName).toBe('button')
+    })
+
+    it('skips exportName without matching prefix', () => {
+        expect(
+            removePrefixFromExportNameIfNeeded({
+                className: 'menu__button',
+                exportName: 'menuButton',
+                prefixesToRemove: [{ prefix: 'repo__', exportName: 'repo' }],
+            })
+        ).toBe('menuButton')
+
+        expect(
+            removePrefixFromExportNameIfNeeded({
+                className: 'menu',
+                exportName: 'menu',
+                prefixesToRemove: [{ prefix: 'menu__', exportName: 'menu' }],
+            })
+        ).toBe('menu')
+    })
+})
+
+describe('getPrefixesToRemove', () => {
+    it('finds all prefixes to remove', () => {
+        const prefixesToRemove = getPrefixesToRemove({
+            'repo-header': 'repoHeader',
+            'repo-header__button': 'repoHeaderButton',
+            'repo-header--alert': 'repoHeaderAlert',
+            'navbar-nav': 'navbarNav',
+            spacer: 'spacer',
+        })
+
+        expect(prefixesToRemove).toEqual([{ prefix: 'repo-header__', exportName: 'repoHeader' }])
+    })
+})

--- a/src/transforms/globalCssToCssModule/postcss/__tests__/getCssModuleExportNameMap.test.ts
+++ b/src/transforms/globalCssToCssModule/postcss/__tests__/getCssModuleExportNameMap.test.ts
@@ -30,7 +30,7 @@ describe('getCssModuleExportNameMap', () => {
 
         expect(exportNameMap).toEqual({
             'repo-header': 'repoHeader',
-            'repo-header__button': 'repoHeaderButton',
+            'repo-header__button': 'button',
             'repo-header--alert': 'repoHeaderAlert',
             'navbar-nav': 'navbarNav',
             spacer: 'spacer',

--- a/src/transforms/globalCssToCssModule/postcss/exportNameMapPrefixes.ts
+++ b/src/transforms/globalCssToCssModule/postcss/exportNameMapPrefixes.ts
@@ -1,0 +1,74 @@
+import { decapitalize, isDefined } from '../../../utils'
+
+interface RemovedPrefix {
+    prefix: string
+    exportName: string
+}
+
+interface RemovePrefixFromExportNameIfNeededOptions {
+    className: string
+    exportName: string
+    prefixesToRemove: RemovedPrefix[]
+}
+
+/**
+ * If `className` starts with `prefix__` and `exportName` starts with `prefix` -> remove `prefix` from the export name.
+ *
+ * ```ts
+ * const exportName = removePrefixFromExportNameIfNeeded({
+ *     className: 'menu__button',
+ *     exportName: 'menuButton',
+ *     prefixesToRemove: [{ prefix: 'menu__', exportName: 'menu' }]
+ * })
+ *
+ * exportName === 'button'
+ * ```
+ */
+export function removePrefixFromExportNameIfNeeded(options: RemovePrefixFromExportNameIfNeededOptions): string {
+    const { className, exportName, prefixesToRemove } = options
+
+    const removedPrefix = prefixesToRemove.find(
+        removedPrefix => exportName.startsWith(removedPrefix.exportName) && className.startsWith(removedPrefix.prefix)
+    )
+
+    if (removedPrefix) {
+        return decapitalize(exportName.replace(removedPrefix.exportName, ''))
+    }
+
+    return exportName
+}
+
+/**
+ * Upon conversion to the CSS module, we lift `&__` nested selectors to the root level:
+ *
+ * ```scss
+ * .menu {
+ *   &__button { ... }
+ * }
+ *
+ * .menu {}
+ * .button {}
+ * ```
+ *
+ * Here `menu__` is a removed prefix because className changed:
+ * .menu__button -> .button
+ *
+ */
+export function getPrefixesToRemove(exportNameMap: Record<string, string>): RemovedPrefix[] {
+    const prefixesToRemove = Object.keys(exportNameMap)
+        .map(key => {
+            const matches = key.match(/(.+)__/)
+
+            if (matches) {
+                return {
+                    prefix: matches[0],
+                    exportName: exportNameMap[matches[1]],
+                }
+            }
+
+            return undefined
+        })
+        .filter(isDefined)
+
+    return [...new Set(prefixesToRemove)]
+}

--- a/src/transforms/globalCssToCssModule/ts/getClassNameNodeReplacement.ts
+++ b/src/transforms/globalCssToCssModule/ts/getClassNameNodeReplacement.ts
@@ -42,6 +42,7 @@ export function getClassNameNodeReplacement(
     options: GetClassNameNodeReplacementOptions
 ): PropertyAccessExpression | JsxExpression | ComputedPropertyName | CallExpression {
     const { parentNode, exportNameReferences } = options
+    const parentKind = parentNode.getKind()
 
     if (exportNameReferences.length === 0) {
         throw new Error('`exportNameReferences` should not be empty!')
@@ -49,19 +50,19 @@ export function getClassNameNodeReplacement(
 
     const replacementWithoutBraces = getClassNameNodeReplacementWithoutBraces(options)
 
-    if (parentNode.getKind() === SyntaxKind.JsxAttribute) {
+    if (parentKind === SyntaxKind.JsxAttribute) {
         return ts.factory.createJsxExpression(undefined, replacementWithoutBraces)
     }
 
-    if (parentNode.getKind() === SyntaxKind.PropertyAssignment) {
+    if (parentKind === SyntaxKind.PropertyAssignment) {
         return ts.factory.createComputedPropertyName(replacementWithoutBraces)
     }
 
-    if (parentNode.getKind() === SyntaxKind.ConditionalExpression) {
+    if (parentKind === SyntaxKind.ConditionalExpression || parentKind === SyntaxKind.CallExpression) {
         // Replace one class string inside of `ConditionalExpression` with the `exportName`.
         // className={classNames('d-flex', isActive ? 'kek' : 'pek')} -> className={classNames('d-flex', isActive ? styles.kek : 'pek')}
         return replacementWithoutBraces
     }
 
-    throw new Error(`Unsupported 'parentNode' type: ${parentNode.compilerNode.kind}`)
+    throw new Error(`Unsupported 'parentNode' type: ${parentNode.getKindName()}`)
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,5 +2,7 @@ export function isDefined<T>(argument: T | undefined): argument is T {
     return argument !== undefined
 }
 
+export const decapitalize = ([first, ...rest]: string): string => first.toLowerCase() + rest.join('')
+
 export * from './formatWithPrettierEslint'
 export * from './formatWithStylelint'


### PR DESCRIPTION
## Context

This PR fixes a bug in the codemod: export names used in components to replace class names have redundant prefixes:

```scss
.menu {
   &__button {}
}
```

Export name map structure: 

```ts
{ 
    [sourceClassName]: exportNameFromCssModuleToReplaceIt
}
```

Export name map _before_ the fix:

```ts
{
   menu: 'menu',
   menu__button: 'menuButton'
}
```

Export name map _after_ the fix:

```ts
{
   menu: 'menu',
   menu__button: 'button'
}
```

Because `&__buton` selector is uplifted to the root level during the CSS module conversion.

## Changes

- Added logic to remove redundant prefixes from the `exportNameMap`.
