### PR TITLE
fix: edge case fixes based on codemod application

### DIFF
--- a/src/transforms/globalCssToCssModule/__tests__/__snapshots__/globalCssToCssModule.test.ts.snap
+++ b/src/transforms/globalCssToCssModule/__tests__/__snapshots__/globalCssToCssModule.test.ts.snap
@@ -48,6 +48,7 @@ exports[`globalCssToCssModule transforms correctly 1`] = `
     :global(.copy-link-action) {
         opacity: 0;
     }
+
     &:hover,
     &:focus-within {
         :global(.copy-link-action) {
@@ -55,43 +56,9 @@ exports[`globalCssToCssModule transforms correctly 1`] = `
         }
     }
 }
-.spacer {
-    flex: 1 1 0;
-}
 
-/* &__icon-chevron { */
-.icon-chevron {
-    opacity: 0.6;
-    margin: auto;
-}
-.alert {
-    margin: 0 0.25rem;
-    padding: 0.125rem 0.25rem;
-    cursor: default;
-    user-select: none;
-}
-
-/* &__action { */
-.action {
-    margin: 0.5rem 0.625rem 0.5rem 0;
-    padding: 0.25rem;
-
-    :global(.theme-light) & {
-        margin-top: 0;
-        margin-bottom: 0;
-    }
-}
-
-/* &__file-action { */
-.file-action {
-    display: block;
-    text-align: left;
-
-    /* span { */
-    span {
-        color: var(--body-color);
-        margin-left: 0.5rem;
-    }
+.logo {
+    display: flex;
 }
 
 /* &__action-list-item { */
@@ -112,12 +79,49 @@ exports[`globalCssToCssModule transforms correctly 1`] = `
     }
 }
 
+/* &__file-action { */
+.file-action {
+    display: block;
+    text-align: left;
+
+    /* span { */
+    span {
+        color: var(--body-color);
+        margin-left: 0.5rem;
+    }
+}
+
+/* &__action { */
+.action {
+    margin: 0.5rem 0.625rem 0.5rem 0;
+    padding: 0.25rem;
+
+    :global(.theme-light) & {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+}
+
+.alert {
+    margin: 0 0.25rem;
+    padding: 0.125rem 0.25rem;
+    cursor: default;
+    user-select: none;
+}
+
+/* &__icon-chevron { */
+.icon-chevron {
+    opacity: 0.6;
+    margin: auto;
+}
+
+.spacer {
+    flex: 1 1 0;
+}
+
 /* &__kek-pek { */
 .kek-pek {
     color: red;
-}
-.logo {
-    display: flex;
 }
 "
 `;

--- a/src/transforms/globalCssToCssModule/globalCssToCssModule.ts
+++ b/src/transforms/globalCssToCssModule/globalCssToCssModule.ts
@@ -9,8 +9,8 @@ import { addClassNamesUtilImportIfNeeded } from '../../utils/classNamesUtility'
 
 import { getCssModuleExportNameMap } from './postcss/getCssModuleExportNameMap'
 import { transformFileToCssModule } from './postcss/transformFileToCssModule'
-import { getNodesWithClassName } from './ts/getNodesWithClassName'
-import { STYLES_IDENTIFIER, processNodesWithClassName } from './ts/processNodesWithClassName'
+import { STYLES_IDENTIFIER } from './ts/processNodesWithClassName'
+import { transformComponentFile } from './ts/transformComponentFile'
 
 /**
  * Convert globally scoped stylesheet tied to the React component into a CSS Module.
@@ -68,11 +68,7 @@ export async function globalCssToCssModule(options: CodemodOptions): CodemodResu
             sourceFilePath: cssFilePath,
         })
 
-        processNodesWithClassName({
-            exportNameMap,
-            nodesWithClassName: getNodesWithClassName(tsSourceFile),
-        })
-
+        transformComponentFile({ tsSourceFile, exportNameMap, cssModuleFileName })
         addClassNamesUtilImportIfNeeded(tsSourceFile)
         tsSourceFile.addImportDeclaration({
             defaultImport: STYLES_IDENTIFIER,

--- a/src/transforms/globalCssToCssModule/postcss/__tests__/transformFileToCssModule.test.ts
+++ b/src/transforms/globalCssToCssModule/postcss/__tests__/transformFileToCssModule.test.ts
@@ -32,6 +32,10 @@ describe('transformFileToCssModule', () => {
                     white-space: nowrap;
                 }
 
+                &:disabled &__button {
+                    display: none;
+                }
+
                 @media (--xs-breakpoint-down) {
                     border-radius: var(--border-radius);
                 }
@@ -67,20 +71,24 @@ describe('transformFileToCssModule', () => {
                         white-space: nowrap;
                     }
 
+                    &:disabled .button {
+                        display: none;
+                    }
+
                     @media (--xs-breakpoint-down) {
                         border-radius: var(--border-radius);
                     }
-                }
-
-                /* &__button comment*/
-                .button {
-                    margin-top: 1px;
                 }
 
                 :global(.theme-light) {
                     .spacer {
                         flex: 1 1 0;
                     }
+                }
+
+                /* &__button comment*/
+                .button {
+                    margin-top: 1px;
                 }
         `
 

--- a/src/transforms/globalCssToCssModule/postcss/exportNameMapPrefixes.ts
+++ b/src/transforms/globalCssToCssModule/postcss/exportNameMapPrefixes.ts
@@ -1,3 +1,5 @@
+import camelcase from 'camelcase'
+
 import { decapitalize, isDefined } from '../../../utils'
 
 interface RemovedPrefix {
@@ -62,7 +64,7 @@ export function getPrefixesToRemove(exportNameMap: Record<string, string>): Remo
             if (matches) {
                 return {
                     prefix: matches[0],
-                    exportName: exportNameMap[matches[1]],
+                    exportName: camelcase(matches[1]),
                 }
             }
 

--- a/src/transforms/globalCssToCssModule/ts/__tests__/getClassNameNodeReplacement.test.ts
+++ b/src/transforms/globalCssToCssModule/ts/__tests__/getClassNameNodeReplacement.test.ts
@@ -52,13 +52,20 @@ describe('getClassNameNodeReplacement', () => {
 
     describe.each(testCases)('in parent kind $parentKind', ({ fileSource, replacement: expectedReplacement }) => {
         const parentNode = getParentFromFirstClassNameNode(fileSource)
-        const getReplacement = (options?: Partial<GetClassNameNodeReplacementOptions>) =>
-            getClassNameNodeReplacement({
+        const getReplacement = (options?: Partial<GetClassNameNodeReplacementOptions>) => {
+            const result = getClassNameNodeReplacement({
                 parentNode,
                 exportNameReferences,
                 leftOverClassName,
                 ...options,
             })
+
+            if (result.isParentTransformed) {
+                throw new Error('No parent transform is expected')
+            }
+
+            return result.replacement
+        }
 
         it('returns correct replacement with `leftOverClassName` provided', () => {
             const replacement = getReplacement()

--- a/src/transforms/globalCssToCssModule/ts/__tests__/processNodesWithClassName.test.ts
+++ b/src/transforms/globalCssToCssModule/ts/__tests__/processNodesWithClassName.test.ts
@@ -21,6 +21,7 @@ describe('processNodesWithClassName', () => {
         `)
 
         processNodesWithClassName({
+            usageStats: {},
             nodesWithClassName: getNodesWithClassName(sourceFile),
             exportNameMap: {
                 kek: 'kek',

--- a/src/transforms/globalCssToCssModule/ts/__tests__/splitClassName.test.ts
+++ b/src/transforms/globalCssToCssModule/ts/__tests__/splitClassName.test.ts
@@ -2,9 +2,13 @@ import { splitClassName } from '../splitClassName'
 
 describe('splitClassName', () => {
     it('splits correctly', () => {
-        const { exportNames, leftOverClassnames } = splitClassName('kek kek--wow d-flex mr-1', {
-            kek: 'kek',
-            'kek--wow': 'kekWow',
+        const { exportNames, leftOverClassnames } = splitClassName({
+            usageStats: {},
+            className: 'kek kek--wow d-flex mr-1',
+            exportNameMap: {
+                kek: 'kek',
+                'kek--wow': 'kekWow',
+            },
         })
 
         expect(exportNames).toEqual(['kek', 'kekWow'])

--- a/src/transforms/globalCssToCssModule/ts/getNodesWithClassName.ts
+++ b/src/transforms/globalCssToCssModule/ts/getNodesWithClassName.ts
@@ -10,9 +10,7 @@ export function getNodesWithClassName(sourceFile: SourceFile): (Identifier | Str
         .filter(identifier => identifier.getParent().compilerNode.kind === SyntaxKind.PropertyAssignment)
 
     // <div className='kek' /> — 'kek' is a `StringLiteral` inside  of the `JsxAttribute`.
-    const classNameStringLiterals = classNameJsxAttributes.flatMap(classNameJsxAttribute =>
-        classNameJsxAttribute.getDescendantsOfKind(SyntaxKind.StringLiteral)
-    )
+    const stringLiterals = sourceFile.getDescendantsOfKind(SyntaxKind.StringLiteral)
 
-    return [...classNameIdentifiers, ...classNameStringLiterals]
+    return [...classNameIdentifiers, ...stringLiterals]
 }

--- a/src/transforms/globalCssToCssModule/ts/splitClassName.ts
+++ b/src/transforms/globalCssToCssModule/ts/splitClassName.ts
@@ -1,22 +1,31 @@
+interface SplitClassNameOptions {
+    className: string
+    exportNameMap: Record<string, string>
+    usageStats: Record<string, boolean>
+}
+
 interface SplitClassNameResult {
     exportNames: string[]
     leftOverClassnames: string[]
 }
 
 /**
- * Example: splitClassName('kek--wow d-flex mr-1', { 'kek--wow': 'kekWow' })
+ * Example: splitClassName({ className: 'kek--wow d-flex mr-1', exportNameMap: { 'kek--wow': 'kekWow' }, usageStats: {})
  * returns: { exportNames: ['kekWow'], leftOverClassnames: ['d-flex', 'mr-1'] }
  *
  * @param className ClassName value string which might contain replaceable parts.
  * @param exportNameMap Mapping between classes and exportNames.
+ * @param usageStats Object to collect replaced classes usage in React component.
  * @returns Object that contains array of exportNames found in the className and the left over value.
  */
-export function splitClassName(className: string, exportNameMap: Record<string, string>): SplitClassNameResult {
+export function splitClassName(options: SplitClassNameOptions): SplitClassNameResult {
+    const { className, exportNameMap, usageStats } = options
     const classNamesToReplace = Object.keys(exportNameMap)
 
     return className.split(' ').reduce<SplitClassNameResult>(
         (accumulator, className) => {
             if (classNamesToReplace.includes(className)) {
+                usageStats[className] = true
                 accumulator.exportNames.push(exportNameMap[className])
             } else {
                 accumulator.leftOverClassnames.push(className)

--- a/src/transforms/globalCssToCssModule/ts/transformComponentFile.ts
+++ b/src/transforms/globalCssToCssModule/ts/transformComponentFile.ts
@@ -1,0 +1,39 @@
+import signale from 'signale'
+import { SourceFile } from 'ts-morph'
+
+import { isDefined } from '../../../utils'
+
+import { getNodesWithClassName } from './getNodesWithClassName'
+import { processNodesWithClassName } from './processNodesWithClassName'
+
+interface TransformComponentFileOptions {
+    tsSourceFile: SourceFile
+    exportNameMap: Record<string, string>
+    cssModuleFileName: string
+}
+
+export function transformComponentFile(options: TransformComponentFileOptions): void {
+    const { tsSourceFile, exportNameMap, cssModuleFileName } = options
+
+    // Object to collect CSS classes usage and report unused classes after the codemod.
+    const usageStats = Object.fromEntries(Object.keys(exportNameMap).map(className => [className, false]))
+
+    let areAllNodesProcessed = false
+
+    while (!areAllNodesProcessed) {
+        // `processNodesWithClassName` returns `true` when there's nothing more to process.
+        areAllNodesProcessed = processNodesWithClassName({
+            usageStats,
+            exportNameMap,
+            nodesWithClassName: getNodesWithClassName(tsSourceFile),
+        })
+    }
+
+    const unusedClassNames = Object.entries(usageStats)
+        .map(([className, isUsed]) => (isUsed ? undefined : className))
+        .filter(isDefined)
+
+    if (unusedClassNames.length > 0) {
+        signale.warn(`Unused CSS classes in ${cssModuleFileName}`, unusedClassNames)
+    }
+}

--- a/src/utils/formatWithStylelint.ts
+++ b/src/utils/formatWithStylelint.ts
@@ -9,6 +9,14 @@ export async function formatWithStylelint(sourceCode: string, filePath: string):
             rules: {
                 // Hard-coded for now. Make it optional or delete it once it's not needed.
                 indentation: 4,
+                'declaration-block-trailing-semicolon': 'always',
+                'rule-empty-line-before': [
+                    'always-multi-line',
+                    {
+                        except: ['after-single-line-comment', 'first-nested'],
+                        ignore: ['after-comment', 'first-nested'],
+                    },
+                ],
             },
         },
     })


### PR DESCRIPTION
## Context

Fixes added in process code-modding the main Sourcegraph repo with `globalCssToCssModule` codemod.

## Changes

- [x] Handle case when CSS class is already inside of the `classNames` call in React component.
- [x] Handle non `classNames` props: e.g., `contentClassName`.
- [x] Preserve original order of styles in CSS module.
- [x] Ensure that redundant prefix is removed from the `exportName`: e.g., `registryExtensionButton` -> `button`.
- [x] Report unused CSS classes.
- [x] Remove empty root CSS class from CSS module.
- [x] Fix missing `;` after last rule in the root CSS class.