### PR TITLE
chore: change `arrow-body-style` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,5 +23,6 @@ module.exports = {
   },
   rules: {
     'no-sync': 'off',
+    'arrow-body-style': ['error', 'always'],
   },
 }

--- a/packages/codemod/src/cli.ts
+++ b/packages/codemod/src/cli.ts
@@ -36,7 +36,11 @@ program
         if (results) {
             if (shouldWriteFiles) {
                 signale.info('Persisting codemod changes to the filesystem...')
-                await Promise.all(results.map(result => result.fsWritePromise))
+                await Promise.all(
+                    results.map(result => {
+                        return result.fsWritePromise
+                    })
+                )
                 signale.info('Persisting codemod changes completed')
             } else {
                 console.log(results)

--- a/packages/codemod/src/transforms/classNameTemplateToClassnamesCall/classNameTemplateToClassnamesCall.ts
+++ b/packages/codemod/src/transforms/classNameTemplateToClassnamesCall/classNameTemplateToClassnamesCall.ts
@@ -21,15 +21,19 @@ export async function classNameTemplateToClassnamesCall(options: CodemodOptions)
         signale.info(`Processing file "${tsFilePath}"`)
 
         const jsxAttributes = tsSourceFile.getDescendantsOfKind(SyntaxKind.JsxAttribute)
-        const classNameJsxAttributes = jsxAttributes.filter(identifier => identifier.getName() === 'className')
+        const classNameJsxAttributes = jsxAttributes.filter(identifier => {
+            return identifier.getName() === 'className'
+        })
 
-        const classNameTemplateExpressions = classNameJsxAttributes.flatMap(classNameJsxAttribute =>
-            classNameJsxAttribute.getDescendantsOfKind(SyntaxKind.TemplateExpression)
-        )
+        const classNameTemplateExpressions = classNameJsxAttributes.flatMap(classNameJsxAttribute => {
+            return classNameJsxAttribute.getDescendantsOfKind(SyntaxKind.TemplateExpression)
+        })
 
         for (const templateExpression of classNameTemplateExpressions) {
             try {
-                templateExpression.transform(() => getTemplateExpressionReplacement(templateExpression))
+                templateExpression.transform(() => {
+                    return getTemplateExpressionReplacement(templateExpression)
+                })
             } catch (error) {
                 console.error(error)
             }

--- a/packages/codemod/src/transforms/globalCssToCssModule/postcss/__tests__/transformFileToCssModule.test.ts
+++ b/packages/codemod/src/transforms/globalCssToCssModule/postcss/__tests__/transformFileToCssModule.test.ts
@@ -1,6 +1,8 @@
 import { transformFileToCssModule } from '../transformFileToCssModule'
 
-const replaceWhitespace = (value: string) => value.replace(/\s+/g, ' ').trim()
+const replaceWhitespace = (value: string) => {
+    return value.replace(/\s+/g, ' ').trim()
+}
 
 describe('transformFileToCssModule', () => {
     it('correctly transforms provided CSS to CSS module', async () => {

--- a/packages/codemod/src/transforms/globalCssToCssModule/postcss/createCssProcessor.ts
+++ b/packages/codemod/src/transforms/globalCssToCssModule/postcss/createCssProcessor.ts
@@ -4,9 +4,10 @@ import postcssScss from 'postcss-scss'
 export const createCssProcessor = (...plugins: AcceptedPlugin[]): ((css: string) => LazyResult) => {
     const configuredProcessor = postcss(plugins)
 
-    return (css: string) =>
-        configuredProcessor.process(css, {
+    return (css: string) => {
+        return configuredProcessor.process(css, {
             parser: postcssScss,
             from: 'CSS',
         })
+    }
 }

--- a/packages/codemod/src/transforms/globalCssToCssModule/postcss/exportNameMapPrefixes.ts
+++ b/packages/codemod/src/transforms/globalCssToCssModule/postcss/exportNameMapPrefixes.ts
@@ -29,9 +29,9 @@ interface RemovePrefixFromExportNameIfNeededOptions {
 export function removePrefixFromExportNameIfNeeded(options: RemovePrefixFromExportNameIfNeededOptions): string {
     const { className, exportName, prefixesToRemove } = options
 
-    const removedPrefix = prefixesToRemove.find(
-        removedPrefix => exportName.startsWith(removedPrefix.exportName) && className.startsWith(removedPrefix.prefix)
-    )
+    const removedPrefix = prefixesToRemove.find(removedPrefix => {
+        return exportName.startsWith(removedPrefix.exportName) && className.startsWith(removedPrefix.prefix)
+    })
 
     if (removedPrefix) {
         return decapitalize(exportName.replace(removedPrefix.exportName, ''))

--- a/packages/codemod/src/transforms/globalCssToCssModule/postcss/getCssModuleExportNameMap.ts
+++ b/packages/codemod/src/transforms/globalCssToCssModule/postcss/getCssModuleExportNameMap.ts
@@ -10,8 +10,9 @@ const EXPORT_NAME_PREFIX = 'prefix'
 // The simplest subset of logic used by css-modules loaders and processors.
 const cssModulesLoaderCore = new CssModuleLoaderCore()
 const noOpPathFetcher = (): void => {}
-const sourceCssToClassNames = (source: Source): Promise<Core.Result> =>
-    cssModulesLoaderCore.load(source, EXPORT_NAME_PREFIX, undefined, noOpPathFetcher)
+const sourceCssToClassNames = (source: Source): Promise<Core.Result> => {
+    return cssModulesLoaderCore.load(source, EXPORT_NAME_PREFIX, undefined, noOpPathFetcher)
+}
 
 const removeCssNestingProcessor = createCssProcessor(postcssNested)
 

--- a/packages/codemod/src/transforms/globalCssToCssModule/postcss/postcssToCssModulePlugin.ts
+++ b/packages/codemod/src/transforms/globalCssToCssModule/postcss/postcssToCssModulePlugin.ts
@@ -31,7 +31,12 @@ export function postcssToCssModulePlugin(options: PostcssToCssModulePluginOption
              * .theme-light -> :global(.theme-light)
              * ```
              */
-            if (isRootRule && globalTopLevelClasses.some(globalClass => parentRule.selector.includes(globalClass))) {
+            if (
+                isRootRule &&
+                globalTopLevelClasses.some(globalClass => {
+                    return parentRule.selector.includes(globalClass)
+                })
+            ) {
                 for (const globalClass of globalTopLevelClasses) {
                     parentRule.selector = parentRule.selector.replace(
                         globalClass,
@@ -234,5 +239,6 @@ function parse(source: string, rule?: Rule): Selector {
         }
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return nodes!.at(0)
 }

--- a/packages/codemod/src/transforms/globalCssToCssModule/ts/__tests__/getClassNameNodeReplacement.test.ts
+++ b/packages/codemod/src/transforms/globalCssToCssModule/ts/__tests__/getClassNameNodeReplacement.test.ts
@@ -13,9 +13,9 @@ describe('getClassNameNodeReplacement', () => {
         return nodeWithClassName.getParent()
     }
 
-    const exportNameReferences = ['button', 'buttonActive'].map(exportName =>
-        ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier('styles'), exportName)
-    )
+    const exportNameReferences = ['button', 'buttonActive'].map(exportName => {
+        return ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier('styles'), exportName)
+    })
 
     const testCases = [
         {
@@ -91,7 +91,9 @@ describe('getClassNameNodeReplacement', () => {
         })
 
         it('throws if `exportNameReferences` is empty', () => {
-            expect(() => getReplacement({ exportNameReferences: [] })).toThrow()
+            expect(() => {
+                return getReplacement({ exportNameReferences: [] })
+            }).toThrow()
         })
     })
 })

--- a/packages/codemod/src/transforms/globalCssToCssModule/ts/getClassNameNodeReplacement.ts
+++ b/packages/codemod/src/transforms/globalCssToCssModule/ts/getClassNameNodeReplacement.ts
@@ -76,12 +76,14 @@ export function getClassNameNodeReplacement(
         if (ts.isCallExpression(parentCompilerNode)) {
             // In case replacement is already in `classNames` call —> transform the parentNode
             // and return `false` to restart node transform to avoid missing nested items which were unmounted during parentNode change.
-            parentNode.transform(() =>
-                ts.factory.createCallExpression(parentCompilerNode.expression, undefined, [
+            parentNode.transform(() => {
+                return ts.factory.createCallExpression(parentCompilerNode.expression, undefined, [
                     ...replacementWithoutBraces,
-                    ...parentCompilerNode.arguments.filter(argument => argument.kind !== SyntaxKind.StringLiteral),
+                    ...parentCompilerNode.arguments.filter(argument => {
+                        return argument.kind !== SyntaxKind.StringLiteral
+                    }),
                 ])
-            )
+            })
 
             return { isParentTransformed: true, replacement: null }
         }

--- a/packages/codemod/src/transforms/globalCssToCssModule/ts/getNodesWithClassName.ts
+++ b/packages/codemod/src/transforms/globalCssToCssModule/ts/getNodesWithClassName.ts
@@ -2,12 +2,18 @@ import { StringLiteral, Identifier, SyntaxKind, SourceFile } from 'ts-morph'
 
 export function getNodesWithClassName(sourceFile: SourceFile): (Identifier | StringLiteral)[] {
     const jsxAttributes = sourceFile.getDescendantsOfKind(SyntaxKind.JsxAttribute)
-    const classNameJsxAttributes = jsxAttributes.filter(identifier => identifier.getName() === 'className')
+    const classNameJsxAttributes = jsxAttributes.filter(identifier => {
+        return identifier.getName() === 'className'
+    })
 
     // <div className={classNames({ kek: isActive })} /> — 'kek' is an `Identifier` inside of the `PropertyAssignment`.
     const classNameIdentifiers = classNameJsxAttributes
-        .flatMap(classNameJsxAttribute => classNameJsxAttribute.getDescendantsOfKind(SyntaxKind.Identifier))
-        .filter(identifier => identifier.getParent().compilerNode.kind === SyntaxKind.PropertyAssignment)
+        .flatMap(classNameJsxAttribute => {
+            return classNameJsxAttribute.getDescendantsOfKind(SyntaxKind.Identifier)
+        })
+        .filter(identifier => {
+            return identifier.getParent().compilerNode.kind === SyntaxKind.PropertyAssignment
+        })
 
     // <div className='kek' /> — 'kek' is a `StringLiteral` inside  of the `JsxAttribute`.
     const stringLiterals = sourceFile.getDescendantsOfKind(SyntaxKind.StringLiteral)

--- a/packages/codemod/src/transforms/globalCssToCssModule/ts/processNodesWithClassName.ts
+++ b/packages/codemod/src/transforms/globalCssToCssModule/ts/processNodesWithClassName.ts
@@ -60,9 +60,9 @@ export function processNodesWithClassName(options: ProcessNodesWithClassNameOpti
             continue
         }
 
-        const exportNameReferences = exportNames.map(exportName =>
-            ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier(STYLES_IDENTIFIER), exportName)
-        )
+        const exportNameReferences = exportNames.map(exportName => {
+            return ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier(STYLES_IDENTIFIER), exportName)
+        })
 
         const result = getClassNameNodeReplacement({
             parentNode: nodeWithClassName.getParent(),
@@ -74,7 +74,9 @@ export function processNodesWithClassName(options: ProcessNodesWithClassNameOpti
             return false
         }
 
-        nodeWithClassName.transform(() => result.replacement)
+        nodeWithClassName.transform(() => {
+            return result.replacement
+        })
     }
 
     return true

--- a/packages/codemod/src/transforms/globalCssToCssModule/ts/transformComponentFile.ts
+++ b/packages/codemod/src/transforms/globalCssToCssModule/ts/transformComponentFile.ts
@@ -16,7 +16,11 @@ export function transformComponentFile(options: TransformComponentFileOptions): 
     const { tsSourceFile, exportNameMap, cssModuleFileName } = options
 
     // Object to collect CSS classes usage and report unused classes after the codemod.
-    const usageStats = Object.fromEntries(Object.keys(exportNameMap).map(className => [className, false]))
+    const usageStats = Object.fromEntries(
+        Object.keys(exportNameMap).map(className => {
+            return [className, false]
+        })
+    )
 
     let areAllNodesProcessed = false
 
@@ -30,7 +34,9 @@ export function transformComponentFile(options: TransformComponentFileOptions): 
     }
 
     const unusedClassNames = Object.entries(usageStats)
-        .map(([className, isUsed]) => (isUsed ? undefined : className))
+        .map(([className, isUsed]) => {
+            return isUsed ? undefined : className
+        })
         .filter(isDefined)
 
     if (unusedClassNames.length > 0) {

--- a/packages/codemod/src/utils/classNamesUtility.ts
+++ b/packages/codemod/src/utils/classNamesUtility.ts
@@ -11,13 +11,13 @@ export function wrapIntoClassNamesUtility(classNames: Expression[]): ts.CallExpr
 
 // Adds `classnames` import to the `sourceFile` if `classNames` util is used and import doesn't exist.
 export function addClassNamesUtilImportIfNeeded(sourceFile: SourceFile): void {
-    const isClassNamesUsed = sourceFile
-        .getDescendantsOfKind(SyntaxKind.Identifier)
-        .some(identifier => identifier.getText() === CLASSNAMES_IDENTIFIER)
+    const isClassNamesUsed = sourceFile.getDescendantsOfKind(SyntaxKind.Identifier).some(identifier => {
+        return identifier.getText() === CLASSNAMES_IDENTIFIER
+    })
 
-    const hasClassNamesImport = sourceFile
-        .getImportDeclarations()
-        .some(declaration => declaration.getModuleSpecifier().getLiteralText() === CLASSNAMES_MODULE_SPECIFIER)
+    const hasClassNamesImport = sourceFile.getImportDeclarations().some(declaration => {
+        return declaration.getModuleSpecifier().getLiteralText() === CLASSNAMES_MODULE_SPECIFIER
+    })
 
     if (isClassNamesUsed && !hasClassNamesImport) {
         sourceFile.addImportDeclaration({

--- a/packages/codemod/src/utils/index.ts
+++ b/packages/codemod/src/utils/index.ts
@@ -2,7 +2,9 @@ export function isDefined<T>(argument: T | undefined): argument is T {
     return argument !== undefined
 }
 
-export const decapitalize = ([first, ...rest]: string): string => first.toLowerCase() + rest.join('')
+export const decapitalize = ([first, ...rest]: string): string => {
+    return first.toLowerCase() + rest.join('')
+}
 
 export * from './formatWithPrettierEslint'
 export * from './formatWithStylelint'

--- a/packages/codemod/src/utils/tests/classNamesUtility.test.ts
+++ b/packages/codemod/src/utils/tests/classNamesUtility.test.ts
@@ -25,7 +25,9 @@ describe('`classNames` helpers', () => {
 
         it('adds `classNames` import if needed', () => {
             const sourceFile = createSourceFile('<div className={classNames("wow")} />')
-            const hasClassNamesImport = () => sourceFile.getText().includes(classNamesImport)
+            const hasClassNamesImport = () => {
+                return sourceFile.getText().includes(classNamesImport)
+            }
 
             expect(hasClassNamesImport()).toBe(false)
             addClassNamesUtilImportIfNeeded(sourceFile)


### PR DESCRIPTION
## Context

It's cumbersome to add `console.log` to arrow functions without curly braces because you need to add them before that manually. And it's a well-known debugging tool! This PR removes the friction of using it. 

We can always roll it back quickly because this rule is auto-fixable.
