### PR TITLE
Wildcard V2: <Icon /> Codemod

### DIFF
--- a/packages/transforms/src/iconToComponent/README.md
+++ b/packages/transforms/src/iconToComponent/README.md
@@ -1,4 +1,3 @@
 # Icon element to `<Icon />` Wildcard component codemod
 
-yarn transform --write --tagToConvert=Link -t ./packages/transforms/src/iconToComponent/iconToComponent.ts '/Users/raphael/Documents/Development/work/Gitstart/client-sourcegraph/client/!(wildcard)/src/\*_/_.{tsx}'
-"/client/web/src/search/\*_/_.tsx"
+yarn transform --write --tagToConvert=Link -t ./packages/transforms/src/iconToComponent/iconToComponent.ts '/sourcegraph/client/!(wildcard)/src/\*_/_.{ts,tsx}'

--- a/packages/transforms/src/iconToComponent/README.md
+++ b/packages/transforms/src/iconToComponent/README.md
@@ -1,3 +1,3 @@
 # Icon element to `<Icon />` Wildcard component codemod
 
-yarn transform --write --tagToConvert=Link -t ./packages/transforms/src/iconToComponent/iconToComponent.ts '/sourcegraph/client/!(wildcard)/src/\*_/_.{ts,tsx}'
+yarn transform --write -t ./packages/transforms/src/iconToComponent/iconToComponent.ts '/sourcegraph/client/!(wildcard)/src/\*_/_.{ts,tsx}'

--- a/packages/transforms/src/iconToComponent/README.md
+++ b/packages/transforms/src/iconToComponent/README.md
@@ -1,0 +1,4 @@
+# Icon element to `<Icon />` Wildcard component codemod
+
+yarn transform --write --tagToConvert=Link -t ./packages/transforms/src/iconToComponent/iconToComponent.ts '/Users/raphael/Documents/Development/work/Gitstart/client-sourcegraph/client/!(wildcard)/src/\*_/_.{tsx}'
+"/client/web/src/search/\*_/_.tsx"

--- a/packages/transforms/src/iconToComponent/__tests__/iconToComponent.test.ts
+++ b/packages/transforms/src/iconToComponent/__tests__/iconToComponent.test.ts
@@ -1,0 +1,48 @@
+import { testCodemod } from '@sourcegraph/codemod-toolkit-ts'
+
+import { iconToComponent } from '../iconToComponent'
+
+testCodemod('iconToComponent', iconToComponent, [
+    {
+        label: 'case 1',
+        initialSource: 'export const Test = <CloseIcon className="icon-inline hello" />',
+        expectedSource: `
+            import { Icon } from '@sourcegraph/wildcard'
+
+            export const Test = <Icon svg={<CloseIcon />} className="hello" />
+        `,
+    },
+    {
+        label: 'case 2',
+        initialSource: 'export const Test = <ConsoleIcon className="icon-inline-md hello" />',
+        expectedSource: `
+            import { Icon } from '@sourcegraph/wildcard'
+
+            export const Test = <Icon svg={<ConsoleIcon />} size="md" className="hello" />
+        `,
+    },
+    {
+        label: 'case 3',
+        initialSource: `
+            import classNames from 'classnames'
+            export const Test = <ConsoleIcon className={classNames('icon-inline-md hello', styles.consoleIcon)} />`,
+        expectedSource: `
+            import classNames from 'classnames'
+
+            import { Icon } from '@sourcegraph/wildcard'
+
+            export const Test = <Icon svg={<ConsoleIcon />} size="md" className={classNames('hello', styles.consoleIcon)} />
+        `,
+    },
+    {
+        label: 'case 4',
+        initialSource: `
+            import classNames from 'classnames'
+            export const Test = <ConsoleIcon aria-label="Console icon" className={classNames('icon-inline-md', styles.consoleIcon)} />`,
+        expectedSource: `
+            import { Icon } from '@sourcegraph/wildcard'
+
+            export const Test = <Icon svg={<ConsoleIcon aria-label="Console icon" />} size="md" className={styles.consoleIcon} />
+        `,
+    },
+])

--- a/packages/transforms/src/iconToComponent/__tests__/iconToComponent.test.ts
+++ b/packages/transforms/src/iconToComponent/__tests__/iconToComponent.test.ts
@@ -9,7 +9,7 @@ testCodemod('iconToComponent', iconToComponent, [
         expectedSource: `
             import { Icon } from '@sourcegraph/wildcard'
 
-            export const Test = <Icon className="hello" svg={CloseIcon} />
+            export const Test = <Icon className="hello" as={CloseIcon} />
         `,
     },
     {
@@ -18,7 +18,7 @@ testCodemod('iconToComponent', iconToComponent, [
         expectedSource: `
             import { Icon } from '@sourcegraph/wildcard'
 
-            export const Test = <Icon className="hello" svg={ConsoleIcon} size="md" />
+            export const Test = <Icon className="hello" as={ConsoleIcon} size="md" />
         `,
     },
     {
@@ -31,7 +31,7 @@ testCodemod('iconToComponent', iconToComponent, [
 
             import { Icon } from '@sourcegraph/wildcard'
 
-            export const Test = <Icon className={classNames('hello', styles.consoleIcon)} svg={ConsoleIcon} size="md" />
+            export const Test = <Icon className={classNames('hello', styles.consoleIcon)} as={ConsoleIcon} size="md" />
         `,
     },
     {
@@ -42,7 +42,7 @@ testCodemod('iconToComponent', iconToComponent, [
         expectedSource: `
             import { Icon } from '@sourcegraph/wildcard'
 
-            export const Test = <Icon aria-label="Console icon" className={styles.consoleIcon} svg={ConsoleIcon} size="md" />
+            export const Test = <Icon aria-label="Console icon" className={styles.consoleIcon} as={ConsoleIcon} size="md" />
         `,
     },
 ])

--- a/packages/transforms/src/iconToComponent/__tests__/iconToComponent.test.ts
+++ b/packages/transforms/src/iconToComponent/__tests__/iconToComponent.test.ts
@@ -9,7 +9,7 @@ testCodemod('iconToComponent', iconToComponent, [
         expectedSource: `
             import { Icon } from '@sourcegraph/wildcard'
 
-            export const Test = <Icon svg={<CloseIcon />} className="hello" />
+            export const Test = <Icon className="hello" svg={CloseIcon} />
         `,
     },
     {
@@ -18,7 +18,7 @@ testCodemod('iconToComponent', iconToComponent, [
         expectedSource: `
             import { Icon } from '@sourcegraph/wildcard'
 
-            export const Test = <Icon svg={<ConsoleIcon />} size="md" className="hello" />
+            export const Test = <Icon className="hello" svg={ConsoleIcon} size="md" />
         `,
     },
     {
@@ -31,7 +31,7 @@ testCodemod('iconToComponent', iconToComponent, [
 
             import { Icon } from '@sourcegraph/wildcard'
 
-            export const Test = <Icon svg={<ConsoleIcon />} size="md" className={classNames('hello', styles.consoleIcon)} />
+            export const Test = <Icon className={classNames('hello', styles.consoleIcon)} svg={ConsoleIcon} size="md" />
         `,
     },
     {
@@ -42,7 +42,7 @@ testCodemod('iconToComponent', iconToComponent, [
         expectedSource: `
             import { Icon } from '@sourcegraph/wildcard'
 
-            export const Test = <Icon svg={<ConsoleIcon aria-label="Console icon" />} size="md" className={styles.consoleIcon} />
+            export const Test = <Icon aria-label="Console icon" className={styles.consoleIcon} svg={ConsoleIcon} size="md" />
         `,
     },
 ])

--- a/packages/transforms/src/iconToComponent/iconClassNamesMapping.ts
+++ b/packages/transforms/src/iconToComponent/iconClassNamesMapping.ts
@@ -1,0 +1,31 @@
+import { ts } from 'ts-morph'
+
+export const ICON_SIZES = ['sm', 'md'] as const
+
+export interface ClassNameMapping {
+    className: string
+    props: {
+        name: string
+        value: ts.Node
+    }[]
+}
+
+const sizeClassNamesMapping: ClassNameMapping[] = ICON_SIZES.map(size => {
+    return {
+        className: `icon-inline-${size}`,
+        props: [
+            {
+                name: 'size',
+                value: ts.factory.createStringLiteral(size),
+            },
+        ],
+    }
+})
+
+export const iconClassNamesMapping: ClassNameMapping[] = [
+    ...sizeClassNamesMapping,
+    {
+        className: 'icon-inline',
+        props: [],
+    },
+]

--- a/packages/transforms/src/iconToComponent/iconToComponent.ts
+++ b/packages/transforms/src/iconToComponent/iconToComponent.ts
@@ -56,7 +56,7 @@ export const iconToComponent = runTransform<IconToComponentOptions>(context => {
 
                 if (isRemoved) {
                     jsxTagElement.addAttribute({
-                        name: 'svg',
+                        name: 'as',
                         initializer: printNode(
                             ts.factory.createJsxExpression(
                                 undefined,

--- a/packages/transforms/src/iconToComponent/iconToComponent.ts
+++ b/packages/transforms/src/iconToComponent/iconToComponent.ts
@@ -1,0 +1,137 @@
+import { JsxAttributeStructure, JsxSpreadAttributeStructure, Node, printNode, StructureKind, ts } from 'ts-morph'
+
+import {
+    removeClassNameAndUpdateJsxElement,
+    addOrUpdateSourcegraphWildcardImportIfNeeded,
+} from '@sourcegraph/codemod-toolkit-packages'
+import {
+    runTransform,
+    getParentUntilOrThrow,
+    isJsxTagElement,
+    getTagName,
+    JsxTagElement,
+} from '@sourcegraph/codemod-toolkit-ts'
+
+import { validateCodemodTarget, validateCodemodTargetOrThrow } from './validateCodemodTarget'
+
+interface IconToComponentOptions {
+    tagToConvert: string
+}
+
+/**
+ * Convert `<SomeIcon class="icon-inline" />` element to the `<Icon svg={<SomeIcon />} />` component.
+ */
+export const iconToComponent = runTransform<IconToComponentOptions>(context => {
+    const { throwManualChangeError, addManualChangeLog } = context
+
+    const jsxTagElementsToUpdate: {
+        jsxTagElement: JsxTagElement
+        props: {
+            name: string
+            value: ts.Node
+        }[]
+    }[] = []
+
+    return {
+        StringLiteral(stringLiteral) {
+            const { classNameMappings } = validateCodemodTargetOrThrow.StringLiteral(stringLiteral)
+            const jsxAttribute = getParentUntilOrThrow(stringLiteral, Node.isJsxAttribute)
+            // console.log(jsxAttribute)
+            if (!/classname/i.test(jsxAttribute.getName())) {
+                return
+            }
+
+            const jsxTagElement = getParentUntilOrThrow(jsxAttribute, isJsxTagElement)
+
+            if (!validateCodemodTarget.JsxTagElement(jsxTagElement)) {
+                throwManualChangeError({
+                    node: jsxTagElement,
+                    message: `Class '${stringLiteral.getLiteralText()}' is used on the '${getTagName(
+                        jsxTagElement
+                    )}' element. Please update it manually.`,
+                })
+            }
+
+            const iconProps: {
+                name: string
+                value: ts.Node
+            }[] = []
+
+            for (const { className, props } of classNameMappings) {
+                const { isRemoved, manualChangeLog } = removeClassNameAndUpdateJsxElement(stringLiteral, className)
+
+                if (manualChangeLog) {
+                    addManualChangeLog(manualChangeLog)
+                }
+
+                if (isRemoved) {
+                    iconProps.push(...props)
+                }
+            }
+
+            jsxTagElementsToUpdate.push({
+                jsxTagElement,
+                props: iconProps,
+            })
+        },
+        SourceFileExit(sourceFile) {
+            if (jsxTagElementsToUpdate.length === 0) {
+                return
+            }
+
+            for (const { jsxTagElement, props } of jsxTagElementsToUpdate) {
+                if (Node.isJsxSelfClosingElement(jsxTagElement)) {
+                    const className = jsxTagElement.getAttribute('className')?.getStructure()
+                    const backup = jsxTagElement
+                        .getAttributes()
+                        .filter(attribute => {
+                            return Node.isJsxSpreadAttribute(attribute) || attribute.getName() !== 'className'
+                        })
+                        .map(attribute => {
+                            return attribute.getStructure()
+                        })
+
+                    jsxTagElement.set({
+                        attributes: backup,
+                    })
+
+                    const beforeDelete = `{${jsxTagElement.print()}}`
+
+                    const iconAttributes: (JsxAttributeStructure | JsxSpreadAttributeStructure)[] = props.map(
+                        property => {
+                            return {
+                                name: property.name,
+                                kind: StructureKind.JsxAttribute,
+                                initializer: printNode(property.value),
+                            }
+                        }
+                    )
+
+                    if (className) {
+                        iconAttributes.push(className)
+                    }
+
+                    iconAttributes.unshift({
+                        name: 'svg',
+                        kind: StructureKind.JsxAttribute,
+                        initializer: beforeDelete,
+                    })
+
+                    jsxTagElement.set({
+                        name: 'Icon',
+                        attributes: iconAttributes,
+                    })
+                }
+            }
+
+            addOrUpdateSourcegraphWildcardImportIfNeeded({
+                sourceFile,
+                importStructure: {
+                    namedImports: ['Icon'],
+                },
+            })
+
+            sourceFile.fixUnusedIdentifiers()
+        },
+    }
+})

--- a/packages/transforms/src/iconToComponent/iconToComponent.ts
+++ b/packages/transforms/src/iconToComponent/iconToComponent.ts
@@ -15,7 +15,6 @@ import {
 
 import { validateCodemodTarget, validateCodemodTargetOrThrow } from './validateCodemodTarget'
 
-
 /**
  * Convert `<SomeIcon class="icon-inline" />` element to the `<Icon svg={<SomeIcon />} />` component.
  */

--- a/packages/transforms/src/iconToComponent/iconToComponent.ts
+++ b/packages/transforms/src/iconToComponent/iconToComponent.ts
@@ -15,14 +15,11 @@ import {
 
 import { validateCodemodTarget, validateCodemodTargetOrThrow } from './validateCodemodTarget'
 
-interface IconToComponentOptions {
-    tagToConvert: string
-}
 
 /**
  * Convert `<SomeIcon class="icon-inline" />` element to the `<Icon svg={<SomeIcon />} />` component.
  */
-export const iconToComponent = runTransform<IconToComponentOptions>(context => {
+export const iconToComponent = runTransform(context => {
     const { throwManualChangeError, addManualChangeLog } = context
 
     const jsxTagElementsToUpdate = new Set<JsxTagElement>()

--- a/packages/transforms/src/iconToComponent/index.ts
+++ b/packages/transforms/src/iconToComponent/index.ts
@@ -1,0 +1,2 @@
+export * from './iconToComponent'
+export * from './validateCodemodTarget'

--- a/packages/transforms/src/iconToComponent/validateCodemodTarget.ts
+++ b/packages/transforms/src/iconToComponent/validateCodemodTarget.ts
@@ -1,0 +1,47 @@
+import { StringLiteral } from 'ts-morph'
+
+import { throwFromMethodsIfUndefinedReturn } from '@sourcegraph/codemod-common'
+import { JsxTagElement } from '@sourcegraph/codemod-toolkit-ts'
+
+import { iconClassNamesMapping, ClassNameMapping } from './iconClassNamesMapping'
+
+interface StringLiteralValidatorResult {
+    stringLiteral: StringLiteral
+    classNameMappings: ClassNameMapping[]
+}
+
+interface JsxTagElementValidatorResult {
+    jsxTagElement: JsxTagElement
+    tagName: string
+}
+
+export const validateCodemodTarget = {
+    /**
+     * Returns `JsxTagElement`.
+     */
+    JsxTagElement(jsxTagElement: JsxTagElement): JsxTagElementValidatorResult | void {
+        const tagName = jsxTagElement.getTagNameNode().getText()
+
+        return { jsxTagElement, tagName }
+    },
+
+    /**
+     * Returns non-void result if received `StringLiteral` has one of icon classes like `icon-inline`.
+     */
+    StringLiteral(stringLiteral: StringLiteral): StringLiteralValidatorResult | void {
+        const classNameMappings = iconClassNamesMapping.filter(({ className }) => {
+            return stringLiteral
+                .getLiteralValue()
+                .split(' ')
+                .some(word => {
+                    return word === className
+                })
+        })
+
+        if (classNameMappings.length !== 0) {
+            return { classNameMappings, stringLiteral }
+        }
+    },
+}
+
+export const validateCodemodTargetOrThrow = throwFromMethodsIfUndefinedReturn(validateCodemodTarget)


### PR DESCRIPTION
## Description
Implement Codemod tool, to automate migration usage of `icon-inline` className to `<Icon/>` wildcard component.

## Refs
[SG Issue](https://github.com/sourcegraph/sourcegraph/issues/27669)
[Gitstart Ticket](https://app.gitstart.com/clients/sourcegraph/tickets/SG-27669)
