### PR TITLE
feat: add Wildcard `Input` codemod

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@ts-morph/bootstrap": "^0.11.1",
+    "@ts-morph/bootstrap": "^0.13.0",
     "camelcase": "^6.2.0",
     "commander": "^8.1.0",
     "css-modules-loader-core": "^1.1.0",
@@ -43,7 +43,7 @@
     "prettier-eslint": "^13.0.0",
     "signale": "^1.4.0",
     "stylelint": "^13.13.1",
-    "ts-morph": "13.0.1",
+    "ts-morph": "14.0.0",
     "ts-node": "^10.1.0",
     "type-fest": "^2.8.0",
     "typescript": "4.5.2"

--- a/packages/toolkit-packages/src/classNames/classNames.ts
+++ b/packages/toolkit-packages/src/classNames/classNames.ts
@@ -1,5 +1,4 @@
 import { Node, ts, SourceFile, CallExpression } from 'ts-morph'
-import { Expression } from 'typescript'
 
 import { addOrUpdateImportIfIdentifierIsUsed, isImportedFromModule } from '@sourcegraph/codemod-toolkit-ts'
 
@@ -7,7 +6,7 @@ export const CLASSNAMES_IDENTIFIER = 'classNames'
 export const CLASSNAMES_MODULE_SPECIFIER = CLASSNAMES_IDENTIFIER.toLowerCase()
 
 // Wraps array of arguments into a `classNames` function call.
-export function wrapIntoClassNamesUtility(classNames: Expression[]): ts.CallExpression {
+export function wrapIntoClassNamesUtility(classNames: ts.Expression[]): ts.CallExpression {
     return ts.factory.createCallExpression(ts.factory.createIdentifier(CLASSNAMES_IDENTIFIER), undefined, classNames)
 }
 

--- a/packages/toolkit-ts/src/manipulation/jsx/__tests__/JsxAttribute.test.ts
+++ b/packages/toolkit-ts/src/manipulation/jsx/__tests__/JsxAttribute.test.ts
@@ -3,15 +3,11 @@ import { removeJsxAttribute, getJsxAttributeStringValue, isJsxAttributeEmpty } f
 
 describe('removeJsxAttribute', () => {
     it('removes Jsx attribute', () => {
-        const node = createJsxOpeningElement('const x = <button type="button" disabled={true}>hey</button>')
+        const node = createJsxOpeningElement('const x = <button type="button" disabled={true} {...rest}>hey</button>')
 
         removeJsxAttribute(node, 'type')
 
-        expect(
-            node.getAttributes().map(attribute => {
-                return attribute.getText()
-            })
-        ).toEqual(['disabled={true}'])
+        expect(node.print()).toEqual('<button disabled={true} {...rest}>')
     })
 })
 

--- a/packages/transforms/src/globalCssToCssModule/ts/getClassNameNodeReplacement.ts
+++ b/packages/transforms/src/globalCssToCssModule/ts/getClassNameNodeReplacement.ts
@@ -1,24 +1,16 @@
 import { ts, NodeParentType, SyntaxKind } from 'ts-morph'
-import {
-    Expression,
-    StringLiteral,
-    CallExpression,
-    JsxExpression,
-    ComputedPropertyName,
-    PropertyAccessExpression,
-} from 'typescript'
 
 import { wrapIntoClassNamesUtility, CLASSNAMES_IDENTIFIER } from '@sourcegraph/codemod-toolkit-packages'
 
 export interface GetClassNameNodeReplacementOptions {
-    parentNode: NodeParentType<StringLiteral>
+    parentNode: NodeParentType<ts.StringLiteral>
     leftOverClassName: string
-    exportNameReferences: PropertyAccessExpression[]
+    exportNameReferences: ts.PropertyAccessExpression[]
 }
 
 function getClassNameNodeReplacementWithoutBraces(
     options: GetClassNameNodeReplacementOptions
-): PropertyAccessExpression | CallExpression | Expression[] {
+): ts.PropertyAccessExpression | ts.CallExpression | ts.Expression[] {
     const { leftOverClassName, exportNameReferences, parentNode } = options
 
     const isInClassnamesCall =
@@ -28,7 +20,7 @@ function getClassNameNodeReplacementWithoutBraces(
     // We need to use `classNames` utility for multiple `exportNames` or for a combination of the `exportName` and `StringLiteral`.
     // className={classNames('d-flex mr-1 kek kek--primary')} -> className={classNames('d-flex mr-1', styles.kek, styles.kekPrimary)}
     if (leftOverClassName || exportNameReferences.length > 1) {
-        const classNamesCallArguments: Expression[] = [...exportNameReferences]
+        const classNamesCallArguments: ts.Expression[] = [...exportNameReferences]
 
         if (leftOverClassName) {
             classNamesCallArguments.unshift(ts.factory.createStringLiteral(leftOverClassName))
@@ -48,7 +40,7 @@ function getClassNameNodeReplacementWithoutBraces(
 
 type GetClassNameNodeReplacementResult =
     | {
-          replacement: PropertyAccessExpression | JsxExpression | ComputedPropertyName | CallExpression
+          replacement: ts.PropertyAccessExpression | ts.JsxExpression | ts.ComputedPropertyName | ts.CallExpression
           isParentTransformed: false
       }
     | {

--- a/packages/transforms/src/inputToComponent/README.md
+++ b/packages/transforms/src/inputToComponent/README.md
@@ -1,0 +1,3 @@
+# Icon element to `<Icon />` Wildcard component codemod
+
+yarn transform --write -t ./packages/transforms/src/inputToComponent/inputToComponent.ts '/sourcegraph/client/!(wildcard)/src/\*_/_.{ts,tsx}'

--- a/packages/transforms/src/inputToComponent/__tests__/inputToComponent.test.ts
+++ b/packages/transforms/src/inputToComponent/__tests__/inputToComponent.test.ts
@@ -1,0 +1,57 @@
+import { testCodemod } from '@sourcegraph/codemod-toolkit-ts'
+
+import { inputToComponent } from '../inputToComponent'
+
+testCodemod('inputToComponent', inputToComponent, [
+    {
+        label: 'case 1',
+        initialSource: 'export const Test = <input className="hello form-control" type="text" {...rest} />',
+        expectedSource: `
+            import { Input } from '@sourcegraph/wildcard'
+
+            export const Test = <Input className="hello" {...rest} />
+        `,
+    },
+    {
+        label: 'case 2',
+        initialSource: 'export const Test = <input className="form-control form-control-sm hello" />',
+        expectedSource: `
+            import { Input } from '@sourcegraph/wildcard'
+
+            export const Test = <Input className="hello" size="sm" />
+        `,
+    },
+    {
+        label: 'case 3',
+        initialSource: `
+            import classNames from 'classnames'
+            export const Test = <input className={classNames('form-control-sm hello', styles.coolInput)} />`,
+        expectedSource: `
+            import classNames from 'classnames'
+
+            import { Input } from '@sourcegraph/wildcard'
+
+            export const Test = <Input className={classNames('hello', styles.coolInput)} size="sm" />
+        `,
+    },
+    {
+        label: 'case 4',
+        initialSource: `
+            import classNames from 'classnames'
+            export const Test = <input aria-label="Console icon" className={classNames('form-control', styles.coolInput)} />`,
+        expectedSource: `
+            import { Input } from '@sourcegraph/wildcard'
+
+            export const Test = <Input aria-label="Console icon" className={styles.coolInput} />
+        `,
+    },
+    {
+        label: 'case 5',
+        initialSource: 'export const Test = <input className="hello" type="text" {...rest} />',
+        expectedSource: `
+            import { Input } from '@sourcegraph/wildcard'
+
+            export const Test = <Input className="hello" {...rest} />
+        `,
+    },
+])

--- a/packages/transforms/src/inputToComponent/index.ts
+++ b/packages/transforms/src/inputToComponent/index.ts
@@ -1,0 +1,2 @@
+export * from './inputToComponent'
+export * from './validateCodemodTarget'

--- a/packages/transforms/src/inputToComponent/inputClassNamesMapping.ts
+++ b/packages/transforms/src/inputToComponent/inputClassNamesMapping.ts
@@ -1,0 +1,31 @@
+import { ts } from 'ts-morph'
+
+export const INPUT_SIZES = ['sm'] as const
+
+export interface ClassNameMapping {
+    className: string
+    props: {
+        name: string
+        value: ts.Node
+    }[]
+}
+
+const sizeClassNamesMapping: ClassNameMapping[] = INPUT_SIZES.map(size => {
+    return {
+        className: `form-control-${size}`,
+        props: [
+            {
+                name: 'size',
+                value: ts.factory.createStringLiteral(size),
+            },
+        ],
+    }
+})
+
+export const inputClassNamesMapping: ClassNameMapping[] = [
+    ...sizeClassNamesMapping,
+    {
+        className: 'form-control',
+        props: [],
+    },
+]

--- a/packages/transforms/src/inputToComponent/inputToComponent.ts
+++ b/packages/transforms/src/inputToComponent/inputToComponent.ts
@@ -1,0 +1,95 @@
+import { Node, printNode } from 'ts-morph'
+
+import {
+    removeClassNameAndUpdateJsxElement,
+    addOrUpdateSourcegraphWildcardImportIfNeeded,
+} from '@sourcegraph/codemod-toolkit-packages'
+import {
+    runTransform,
+    getParentUntilOrThrow,
+    isJsxTagElement,
+    getTagName,
+    JsxTagElement,
+    setOnJsxTagElement,
+    getJsxAttributeStringValue,
+    removeJsxAttribute,
+} from '@sourcegraph/codemod-toolkit-ts'
+
+import { validateCodemodTarget, validateCodemodTargetOrThrow } from './validateCodemodTarget'
+
+/**
+ * Convert `<input class="form-control" />` element to the `<Input />` component.
+ */
+export const inputToComponent = runTransform(context => {
+    const { throwManualChangeError, addManualChangeLog } = context
+
+    const jsxTagElementsToUpdate = new Set<JsxTagElement>()
+
+    return {
+        JsxSelfClosingElement(jsxTagElement) {
+            if (validateCodemodTarget.JsxTagElement(jsxTagElement)) {
+                jsxTagElementsToUpdate.add(jsxTagElement)
+            }
+        },
+        StringLiteral(stringLiteral) {
+            const { classNameMappings } = validateCodemodTargetOrThrow.StringLiteral(stringLiteral)
+            const jsxAttribute = getParentUntilOrThrow(stringLiteral, Node.isJsxAttribute)
+
+            if (!/classname/i.test(jsxAttribute.getName())) {
+                return
+            }
+
+            const jsxTagElement = getParentUntilOrThrow(jsxAttribute, isJsxTagElement)
+
+            if (!validateCodemodTarget.JsxTagElement(jsxTagElement)) {
+                throwManualChangeError({
+                    node: jsxTagElement,
+                    message: `Class '${stringLiteral.getLiteralText()}' is used on the '${getTagName(
+                        jsxTagElement
+                    )}' element. Please update it manually.`,
+                })
+            }
+
+            for (const { className, props } of classNameMappings) {
+                const { isRemoved, manualChangeLog } = removeClassNameAndUpdateJsxElement(stringLiteral, className)
+
+                if (manualChangeLog) {
+                    addManualChangeLog(manualChangeLog)
+                }
+
+                if (isRemoved) {
+                    for (const { name, value } of props) {
+                        jsxTagElement.addAttribute({
+                            name,
+                            initializer: printNode(value),
+                        })
+                    }
+                }
+            }
+
+            jsxTagElementsToUpdate.add(jsxTagElement)
+        },
+        SourceFileExit(sourceFile) {
+            if (jsxTagElementsToUpdate.size === 0) {
+                return
+            }
+
+            for (const jsxTagElement of jsxTagElementsToUpdate) {
+                if (getJsxAttributeStringValue(jsxTagElement, 'type') === 'text') {
+                    removeJsxAttribute(jsxTagElement, 'type')
+                }
+
+                setOnJsxTagElement(jsxTagElement, { name: 'Input' })
+            }
+
+            addOrUpdateSourcegraphWildcardImportIfNeeded({
+                sourceFile,
+                importStructure: {
+                    namedImports: ['Input'],
+                },
+            })
+
+            sourceFile.fixUnusedIdentifiers()
+        },
+    }
+})

--- a/packages/transforms/src/inputToComponent/validateCodemodTarget.ts
+++ b/packages/transforms/src/inputToComponent/validateCodemodTarget.ts
@@ -1,0 +1,49 @@
+import { StringLiteral } from 'ts-morph'
+
+import { throwFromMethodsIfUndefinedReturn } from '@sourcegraph/codemod-common'
+import { JsxTagElement } from '@sourcegraph/codemod-toolkit-ts'
+
+import { inputClassNamesMapping, ClassNameMapping } from './inputClassNamesMapping'
+
+interface StringLiteralValidatorResult {
+    stringLiteral: StringLiteral
+    classNameMappings: ClassNameMapping[]
+}
+
+interface JsxTagElementValidatorResult {
+    jsxTagElement: JsxTagElement
+    tagName: string
+}
+
+export const validateCodemodTarget = {
+    /**
+     * Returns `JsxTagElement`.
+     */
+    JsxTagElement(jsxTagElement: JsxTagElement, bannedTagName = 'input'): JsxTagElementValidatorResult | void {
+        const tagName = jsxTagElement.getTagNameNode().getText()
+
+        if (tagName === bannedTagName) {
+            return { jsxTagElement, tagName }
+        }
+    },
+
+    /**
+     * Returns non-void result if received `StringLiteral` has one of icon classes like `icon-inline`.
+     */
+    StringLiteral(stringLiteral: StringLiteral): StringLiteralValidatorResult | void {
+        const classNameMappings = inputClassNamesMapping.filter(({ className }) => {
+            return stringLiteral
+                .getLiteralValue()
+                .split(' ')
+                .some(word => {
+                    return word === className
+                })
+        })
+
+        if (classNameMappings.length !== 0) {
+            return { classNameMappings, stringLiteral }
+        }
+    },
+}
+
+export const validateCodemodTargetOrThrow = throwFromMethodsIfUndefinedReturn(validateCodemodTarget)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,30 +1159,20 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@ts-morph/bootstrap@^0.11.1":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@ts-morph/bootstrap/-/bootstrap-0.11.1.tgz#f8415e2e08cafec6a1118dd016db950bcebe2888"
-  integrity sha512-LMSNhjEe0p5GhUPt2hjuX/KLz4LN0PD/mELUo/XNXdGNGO74WaS6QSymSdoT739yYNuKrcuLG9tBGkJWNr5Nyg==
+"@ts-morph/bootstrap@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@ts-morph/bootstrap/-/bootstrap-0.13.0.tgz#f08f3f3c4c930c79275eb2be40196b8b04956902"
+  integrity sha512-pvzBE1ub6T+JZqqCzF+bHwM8LsT0T0tAwrYTaNOX9pKEJamzjQzg2owWcQTLeY3dXK0gIQpNKN/EDdY7tQmobQ==
   dependencies:
-    "@ts-morph/common" "~0.11.1"
+    "@ts-morph/common" "~0.13.0"
 
-"@ts-morph/common@~0.11.1":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.11.1.tgz#281af2a0642b19354d8aa07a0d50dfdb4aa8164e"
-  integrity sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==
+"@ts-morph/common@~0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.13.0.tgz#77dea1565baaf002d1bc2c20e05d1fb3349008a9"
+  integrity sha512-fEJ6j7Cu8yiWjA4UmybOBH9Efgb/64ZTWuvCF4KysGu4xz8ettfyaqFt8WZ1btCxXsGZJjZ2/3svOF6rL+UFdQ==
   dependencies:
-    fast-glob "^3.2.7"
-    minimatch "^3.0.4"
-    mkdirp "^1.0.4"
-    path-browserify "^1.0.1"
-
-"@ts-morph/common@~0.12.1":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.12.2.tgz#61d07a47d622d231e833c44471ab306faaa41aed"
-  integrity sha512-m5KjptpIf1K0t0QL38uE+ol1n+aNn9MgRq++G3Zym1FlqfN+rThsXlp3cAgib14pIeXF7jk3UtJQOviwawFyYg==
-  dependencies:
-    fast-glob "^3.2.7"
-    minimatch "^3.0.4"
+    fast-glob "^3.2.11"
+    minimatch "^5.0.1"
     mkdirp "^1.0.4"
     path-browserify "^1.0.1"
 
@@ -2061,6 +2051,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.1:
   version "3.0.2"
@@ -3381,10 +3378,21 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.1.1, fast-glob@^3.2.5, fast-glob@^3.2.7:
+fast-glob@^3.1.1, fast-glob@^3.2.5:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
   integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.11:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -5457,6 +5465,13 @@ minimatch@^3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist-options@4.1.0:
   version "4.1.0"
@@ -7635,12 +7650,12 @@ ts-jest@^27.1.2:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-morph@13.0.1:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-13.0.1.tgz#08b99187108f53514e475097e47c5d672f7ef7b6"
-  integrity sha512-nJQm/Yz8utWAqieZHkY5Phphzi62kulNEOiliqnarzGpPBrWSsdn2Pz+DP7gulwyg/LRaFifvtSAsbvxylwAnw==
+ts-morph@14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-14.0.0.tgz#6bffb7e4584cf6a9aebce2066bf4258e1d03f9fa"
+  integrity sha512-tO8YQ1dP41fw8GVmeQAdNsD8roZi1JMqB7YwZrqU856DvmG5/710e41q2XauzTYrygH9XmMryaFeLo+kdCziyA==
   dependencies:
-    "@ts-morph/common" "~0.12.1"
+    "@ts-morph/common" "~0.13.0"
     code-block-writer "^11.0.0"
 
 ts-node@^10.1.0, ts-node@^10.4.0:


### PR DESCRIPTION
## Context

The codemod required for [the Wildcard `Input` migration](https://github.com/sourcegraph/sourcegraph/issues/27722).

## Changes

- Added the `Input` codemod.
- Upgraded `ts-morph` to the latest version to fix printer bugs.

## How to test

```sh
yarn transform --write -t ./packages/transforms/src/inputToComponent/inputToComponent.ts '{SOURCEGRAPH_LOCAL_PATH}/client/!(wildcard)/src/**/*.{ts,tsx}'
```