### PR TITLE
chore: disble `use-button-component` rule

### DIFF
--- a/.changeset/tame-kangaroos-promise.md
+++ b/.changeset/tame-kangaroos-promise.md
@@ -1,0 +1,5 @@
+---
+'@sourcegraph/eslint-plugin-sourcegraph': patch
+---
+
+Disabled the `use-button-component` rule

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,20 +4,20 @@
 
 ### Patch Changes
 
--   [#117](https://github.com/sourcegraph/codemod/pull/117) [`a72a1c3`](https://github.com/sourcegraph/codemod/commit/a72a1c34ad6422aee71fa000f18326ac2124e9d7) Thanks [@valerybugakov](https://github.com/valerybugakov)! - Imported the `check-help-links` eslint-plugin rule.
+- [#117](https://github.com/sourcegraph/codemod/pull/117) [`a72a1c3`](https://github.com/sourcegraph/codemod/commit/a72a1c34ad6422aee71fa000f18326ac2124e9d7) Thanks [@valerybugakov](https://github.com/valerybugakov)! - Imported the `check-help-links` eslint-plugin rule.
 
 ## 1.0.2
 
 ### Patch Changes
 
--   [#115](https://github.com/sourcegraph/codemod/pull/115) [`309ca9b`](https://github.com/sourcegraph/codemod/commit/309ca9bfede3296e2813fa460c157bca3d0fcc1e) Thanks [@valerybugakov](https://github.com/valerybugakov)! - Upgraded `stylelint` version.
+- [#115](https://github.com/sourcegraph/codemod/pull/115) [`309ca9b`](https://github.com/sourcegraph/codemod/commit/309ca9bfede3296e2813fa460c157bca3d0fcc1e) Thanks [@valerybugakov](https://github.com/valerybugakov)! - Upgraded `stylelint` version.
 
--   Updated dependencies [[`309ca9b`](https://github.com/sourcegraph/codemod/commit/309ca9bfede3296e2813fa460c157bca3d0fcc1e)]:
-    -   @sourcegraph/codemod-transforms@1.0.2
+- Updated dependencies [[`309ca9b`](https://github.com/sourcegraph/codemod/commit/309ca9bfede3296e2813fa460c157bca3d0fcc1e)]:
+  - @sourcegraph/codemod-transforms@1.0.2
 
 ## 1.0.1
 
 ### Patch Changes
 
--   Updated dependencies []:
-    -   @sourcegraph/codemod-transforms@1.0.1
+- Updated dependencies []:
+  - @sourcegraph/codemod-transforms@1.0.1

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -2,10 +2,4 @@
 // DO NOT EDIT THIS CODE BY HAND
 // YOU CAN REGENERATE IT USING yarn generate:configs
 
-export = {
-    extends: ['./configs/base'],
-    rules: {
-        '@sourcegraph/sourcegraph/check-help-links': 'error',
-        '@sourcegraph/sourcegraph/use-button-component': 'error',
-    },
-}
+export = { extends: ['./configs/base'], rules: { '@sourcegraph/sourcegraph/check-help-links': 'error' } }

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,9 +1,7 @@
 // This file is used by `scripts/generate-configs.ts` for rules extraction.
 import { checkHelpLinks } from './check-help-links'
-import { useButtonComponent } from './use-button-component'
 
 // eslint-disable-next-line import/no-default-export
 export default {
-    'use-button-component': useButtonComponent,
     'check-help-links': checkHelpLinks,
 }

--- a/packages/eslint-plugin/tsconfig.build.json
+++ b/packages/eslint-plugin/tsconfig.build.json
@@ -4,5 +4,5 @@
     "rootDir": "./src",
   },
   "include": ["src", "types"],
-  "exclude": ["./src/**/*.test.ts", "./src/**/fixtures"],
+  "exclude": ["./src/**/*.test.ts", "./src/**/fixtures", "./src/testing/**"],
 }


### PR DESCRIPTION
## Context

Removed the `use-button-component` rule from exports for now. 