### PR TITLE
lint: Add linter rule to ban uncommented empty catch blocks

### DIFF
--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -2,4 +2,10 @@
 // DO NOT EDIT THIS CODE BY HAND
 // YOU CAN REGENERATE IT USING yarn generate:configs
 
-export = { extends: ['./configs/base'], rules: { '@sourcegraph/sourcegraph/check-help-links': 'error' } }
+export = {
+    extends: ['./configs/base'],
+    rules: {
+        '@sourcegraph/sourcegraph/check-help-links': 'error',
+        '@sourcegraph/sourcegraph/no-empty-catch-blocks': 'error',
+    },
+}

--- a/packages/eslint-plugin/src/rules/check-help-links/check-help-links.md
+++ b/packages/eslint-plugin/src/rules/check-help-links/check-help-links.md
@@ -17,6 +17,6 @@ If neither of these are set, then the rule will silently succeed.
 
 ```jsonc
 {
-  "@sourcegraph/check-help-links": "error"
+  "@sourcegraph/sourcegraph/check-help-links": "error"
 }
 ```

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -1,7 +1,9 @@
 // This file is used by `scripts/generate-configs.ts` for rules extraction.
 import { checkHelpLinks } from './check-help-links'
+import { noEmptyCatchBlocks } from './no-empty-catch-blocks'
 
 // eslint-disable-next-line import/no-default-export
 export default {
     'check-help-links': checkHelpLinks,
+    'no-empty-catch-blocks': noEmptyCatchBlocks
 }

--- a/packages/eslint-plugin/src/rules/no-empty-catch-blocks/__tests__/no-empty-catch-blocks.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-catch-blocks/__tests__/no-empty-catch-blocks.test.ts
@@ -1,0 +1,44 @@
+import { getFixturesRootDir, RuleTester } from "../../../testing/RuleTester"
+import { noEmptyCatchBlocks } from "../no-empty-catch-blocks"
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        tsconfigRootDir: getFixturesRootDir(),
+        project: './tsconfig.json',
+    },
+    parser: '@typescript-eslint/parser',
+})
+
+ruleTester.run('no-empty-catch-blocks', noEmptyCatchBlocks, {
+    valid: [
+        {
+            code: `
+                try {}
+                /* Ignore this error */
+                catch {}
+            `,
+        },
+        {
+            code: `
+                try {}
+                catch {
+                    // Ignore this error
+                }
+            `,
+        },
+        {
+            code: `
+                try {}
+                catch (error) {
+                    Sentry.captureException(error)
+                }
+            `,
+        },
+    ],
+    invalid: [
+        {
+            code: `try {} catch {}`,
+            errors: [{ messageId: 'noEmptyCatchBlocks' }]
+        },
+    ],
+})

--- a/packages/eslint-plugin/src/rules/no-empty-catch-blocks/index.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-catch-blocks/index.ts
@@ -1,0 +1,1 @@
+export * from './no-empty-catch-blocks'

--- a/packages/eslint-plugin/src/rules/no-empty-catch-blocks/no-empty-catch-blocks.md
+++ b/packages/eslint-plugin/src/rules/no-empty-catch-blocks/no-empty-catch-blocks.md
@@ -1,0 +1,41 @@
+# Ban unexplained empty `catch` blocks
+
+## Rule details
+
+This rule bans `catch` blocks that have an empty body, unless the block is supported by a helpful comment explaining why this exception can be safely ignore and not processed.
+
+### Bad code
+
+```ts
+try {
+  // do something
+} catch (error) {}
+```
+
+### Good code
+
+```ts
+try {
+  // do something
+} catch (error) {
+  // This error can be ignored because XYZ.
+}
+```
+
+### (Bonus) Awesome code
+
+```ts
+try {
+  // do something
+} catch (error) {
+  Sentry.captureException(error) // ...or something like this
+}
+```
+
+## How to Use
+
+```jsonc
+{
+  "@sourcegraph/sourcegraph/no-empty-catch-blocks": "error"
+}
+```

--- a/packages/eslint-plugin/src/rules/no-empty-catch-blocks/no-empty-catch-blocks.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-catch-blocks/no-empty-catch-blocks.ts
@@ -1,0 +1,40 @@
+
+import { createRule } from '../../utils'
+
+export const messages = {
+    noEmptyCatchBlocks: 'Catch blocks should not be empty. Either process the error, or comment why the exception can be ignored',
+}
+
+export const noEmptyCatchBlocks = createRule<[], keyof typeof messages>({
+    name: 'no-empty-catch-blocks',
+    meta: {
+        docs: {
+            description: 'Bans usage of the empty catch blocks, unless supported by a comment explaining why the exception can be ignored.',
+            recommended: 'error',
+        },
+        messages,
+        schema: [],
+        type: 'problem',
+    },
+    defaultOptions: [],
+    create(context) {
+        const sourceCode = context.getSourceCode()
+
+        return {
+            CatchClause(node) {
+                // Get all comments inside the catch block, and right before it
+                const comments = [
+                    ...sourceCode.getCommentsBefore(node),
+                    ...sourceCode.getCommentsInside(node)
+                ]
+                // If the catch body is empty and there are no comments, report error
+                if (node.body.body.length === 0 && comments.length === 0) {
+                    context.report({
+                        node,
+                        messageId: 'noEmptyCatchBlocks',
+                    })
+                }
+            }
+        }
+    },
+})

--- a/packages/eslint-plugin/src/rules/use-button-component/__tests__/use-button-component.test.ts
+++ b/packages/eslint-plugin/src/rules/use-button-component/__tests__/use-button-component.test.ts
@@ -1,4 +1,4 @@
-import { RuleTester, getFixturesRootDir, addReactFilename } from '../../../testing/RuleTester'
+import { RuleTester, getFixturesRootDir, addFilename } from '../../../testing/RuleTester'
 import { useButtonComponent } from '../use-button-component'
 
 const ruleTester = new RuleTester({
@@ -10,7 +10,7 @@ const ruleTester = new RuleTester({
 })
 
 ruleTester.run('use-button-component', useButtonComponent, {
-    valid: addReactFilename([
+    valid: addFilename('react.tsx', [
         {
             code: '<Button variant="primary" className="d-flex" />',
         },
@@ -21,7 +21,7 @@ ruleTester.run('use-button-component', useButtonComponent, {
             code: '<div><div className="d-flex btn-another" /></div>',
         },
     ]),
-    invalid: addReactFilename([
+    invalid: addFilename('react.tsx', [
         {
             code: '<button />',
             errors: [


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/26581

This rule bans `catch` blocks that have an empty body, unless the block is supported by a helpful comment explaining why this exception can be safely ignore and not processed.

### Bad code

```ts
try {
  // do something
} catch (error) {}
```

### Good code

```ts
try {
  // do something
} catch (error) {
  // This error can be ignored because XYZ.
}
```

### (Bonus) Awesome code

```ts
try {
  // do something
} catch (error) {
  Sentry.captureException(error) // ...or something like this
}
```
