### PR TITLE
ci: update to actions/checkout@v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0

--- a/.github/workflows/scip.yml
+++ b/.github/workflows/scip.yml
@@ -5,7 +5,7 @@ jobs:
   index:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
Update to actions/checkout@v3 to avoid deprecation warning

### Test plan
Created as part of batch change: [_Created by Sourcegraph batch change `sourcegraph-operator-dax/Upgrade_actions_checkout_v2-v3`._](https://sourcegraph.sourcegraph.com/users/sourcegraph-operator-dax/batch-changes/Upgrade_actions_checkout_v2-v3)